### PR TITLE
Minor bug fixes and performance improvements

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,7 +1,7 @@
 {
     "root": true,
     "parserOptions": {
-        "ecmaVersion": 2017,
+        "ecmaVersion": 12,
         "sourceType": "module",
         "ecmaFeatures": {
             "impliedStrict": true

--- a/README.md
+++ b/README.md
@@ -7,13 +7,13 @@
 
 <img height="200" width="200" src="assets/header.svg">
 
-This is a (Firefox and Thunderbird) add-on (WebExtension) that allows you to autocorrect common text sequences and convert text characters to a look like a special font.
+This is a (Firefox, Chromium/Chrome and Thunderbird) add-on (WebExtension) that allows you to autocorrect common text sequences and convert text characters to a look like a special font.
 For instance, it converts quotes like `"these"` to `“these”`, which are typographically correct.
 
 Additionally, you can convert text into more than 20 different font styles and casing changes.
 You can enable and disable any features in the options and adjust more settings regarding the behavior of the add-on.
 
-This extension only works with modern Firefox and Thunderbird v78 or higher.
+This extension works with modern Firefox v78 or higher, Chromium/Chrome and Thunderbird v78 or higher.
 
 ## Download
 

--- a/src/background/modules/AutocorrectHandler.js
+++ b/src/background/modules/AutocorrectHandler.js
@@ -87,9 +87,9 @@ function applySettings() {
     antipatterns = antipatterns.filter((item, pos) => antipatterns.indexOf(item) === pos);
     console.log("Do not autocorrect for these patterns", antipatterns);
 
-    antipatterns.forEach((symbol, index) => {
+    for (const [index, symbol] of antipatterns.entries()) {
         antipatterns[index] = symbol.replace(regExSpecialChars, "\\$&");
-    });
+    }
 
     symbolpatterns = new RegExp(`(${symbolpatterns.join("|")})$`);
     antipatterns = new RegExp(`(${antipatterns.join("|")})$`);
@@ -130,7 +130,7 @@ function sendSettings(autocorrect) {
 
     browser.tabs.query({}).then((tabs) => {
         for (const tab of tabs) {
-            // This is currently not supported in Thunderbird: https://bugzilla.mozilla.org/show_bug.cgi?id=1641576
+            // This requires Thunderbird 78.4: https://bugzilla.mozilla.org/show_bug.cgi?id=1641576
             browser.tabs.sendMessage(
                 tab.id,
                 {

--- a/src/common/modules/UnicodeTransformationHandler.js
+++ b/src/common/modules/UnicodeTransformationHandler.js
@@ -53,7 +53,7 @@ export function getTransformationType(transformationId) {
 function capitalizeEachWord(text) {
     // Regular expression Unicode property escapes and lookbehind assertions require Firefox/Thunderbird 78
     // see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp#bcd:javascript.builtins.RegExp
-    return text.replace(/(?<=^|\P{Alpha})\p{Alpha}\S*/gu, ([h, ...t]) => h.toLocaleUpperCase() + t.join(''));
+    return text.replace(/(?<=^|\P{Alpha})\p{Alpha}\S*/gu, ([h, ...t]) => h.toLocaleUpperCase() + t.join(""));
 }
 
 /**

--- a/src/content_scripts/autocorrect.js
+++ b/src/content_scripts/autocorrect.js
@@ -66,6 +66,9 @@ function getCaretPosition(target) {
     if (target.isContentEditable || IS_THUNDERBIRD) {
         target.focus();
         const _range = document.getSelection().getRangeAt(0);
+        if (!_range.collapsed) {
+            return null;
+        }
         const range = _range.cloneRange();
         const temp = document.createTextNode("\0");
         range.insertNode(temp);
@@ -75,6 +78,9 @@ function getCaretPosition(target) {
     }
     // input and textarea fields
     else {
+        if (target.selectionStart !== target.selectionEnd) {
+            return null;
+        }
         return target.selectionStart;
     }
 }
@@ -89,9 +95,9 @@ function getCaretPosition(target) {
  * @returns {void}
  */
 function insertAtCaret(target, atext) {
-    const isSuccess = document.execCommand("insertText", false, atext);
-
-    if(isSuccess) {
+    // document.execCommand is deprecated, although there is not yet an alternative: https://developer.mozilla.org/en-US/docs/Web/API/Document/execCommand
+    // insertReplacementText
+    if(document.execCommand("insertText", false, atext)) {
         return;
     }
 
@@ -157,8 +163,8 @@ function countChars(str) {
 function deleteCaret(target, atext) {
     const count = countChars(atext);
     if (count > 0) {
-        const isSuccess = document.execCommand("delete", false);
-        if (isSuccess) {
+        // document.execCommand is deprecated, although there is not yet an alternative: https://developer.mozilla.org/en-US/docs/Web/API/Document/execCommand
+        if (document.execCommand("delete", false)) {
             for (let i = 0; i < count - 1; ++i) {
                 document.execCommand("delete", false);
             }


### PR DESCRIPTION
* Disables autocorrections when text is selected.
    * On Slack, pressing backspace with selected text would delete the whole paragraph for some reason.
* Fixes race condition.
    * Waits for the all context menu items to be created before refreshing the menu.
* Minor ESLint fixes.
* Updated comments.
* Improved performance.
    * Removed unnecessary code.
    * Shortened the context menu preview length. The new Proton UI in Firefox 89 seems to significantly shrink the maximum context menu width, so this accounts for that.
* Added Chromium/Chrome to README.

The above changes that are applicable to https://github.com/rugk/awesome-emoji-picker/pull/93/ were backported in https://github.com/rugk/awesome-emoji-picker/pull/93/commits/78220fc9f9b6b1c828bc16327520a9de273148d6.