### PR TITLE
Updated autocorrect to not match version numbers

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -10,7 +10,7 @@
     "env": {
         "browser": true,
         "webextensions": true,
-        "es6": true
+        "es2021": true
     },
     "extends": "eslint:recommended",
     "rules": {

--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+github: [rugk, tdulcet]

--- a/scripts/manifests/chromemanifest.json
+++ b/scripts/manifests/chromemanifest.json
@@ -1,6 +1,6 @@
 {
   "manifest_version": 2,
-  "name": "Unicodify DEV VERSION",
+  "name": "__MSG_extensionName__",
   "short_name": "__MSG_extensionNameShort__",
   "version": "0.1",
   "author": "Teal Dulcet, rugk",

--- a/scripts/manifests/thunderbirdmanifest.json
+++ b/scripts/manifests/thunderbirdmanifest.json
@@ -36,6 +36,7 @@
 
   "permissions": [
     "storage",
+    "<all_urls>",
     "tabs",
     "compose",
     "menus"

--- a/scripts/manifests/thunderbirdmanifest.json
+++ b/scripts/manifests/thunderbirdmanifest.json
@@ -36,7 +36,6 @@
 
   "permissions": [
     "storage",
-    "<all_urls>",
     "tabs",
     "compose",
     "menus"

--- a/src/background/modules/AutocorrectHandler.js
+++ b/src/background/modules/AutocorrectHandler.js
@@ -18,7 +18,7 @@ let autocorrections = {};
 let longest = 0;
 
 let symbolpatterns = [];
-// Do not autocorrect for these patterns
+// Exceptions, do not autocorrect for these patterns
 let antipatterns = [];
 
 // Chrome
@@ -48,13 +48,10 @@ function applySettings() {
     }
     console.log("Longest autocorrection", longest);
 
-    symbolpatterns = [];
     // Escape special characters
     const regExSpecialChars = /[.*+?^${}()|[\]\\]/g;
 
-    for (const symbol in autocorrections) {
-        symbolpatterns.push(symbol.replace(regExSpecialChars, "\\$&"));
-    }
+    symbolpatterns = Object.keys(autocorrections).map((symbol) => symbol.replace(regExSpecialChars, "\\$&"));
 
     // Do not autocorrect for these patterns
     antipatterns = [];
@@ -87,9 +84,7 @@ function applySettings() {
     antipatterns = antipatterns.filter((item, pos) => antipatterns.indexOf(item) === pos);
     console.log("Do not autocorrect for these patterns", antipatterns);
 
-    for (const [index, symbol] of antipatterns.entries()) {
-        antipatterns[index] = symbol.replace(regExSpecialChars, "\\$&");
-    }
+    antipatterns = antipatterns.map((symbol) => symbol.replace(regExSpecialChars, "\\$&"));
 
     symbolpatterns = new RegExp(`(${symbolpatterns.join("|")})$`);
     antipatterns = new RegExp(`(${antipatterns.join("|")})$`);

--- a/src/background/modules/ContextMenu.js
+++ b/src/background/modules/ContextMenu.js
@@ -64,7 +64,7 @@ async function handleMenuShown(info) {
     // shorten preview text as it may not be shown anyway
     if (text.length > PREVIEW_STRING_CUT_LENGTH) {
         // to be sure, we append … anyway, in case some strange OS has a tooltip for context menus or so
-        text = `${text.substr(0, PREVIEW_STRING_CUT_LENGTH)}…`;
+        text = `${text.substring(0, PREVIEW_STRING_CUT_LENGTH)}…`;
     }
     text = text.normalize();
 

--- a/src/background/modules/ContextMenu.js
+++ b/src/background/modules/ContextMenu.js
@@ -50,6 +50,10 @@ function handleMenuChoosen(info, tab) {
  * @throws {Error}
  */
 async function handleMenuShown(info) {
+    if (!info.editable) {
+        return;
+    }
+
     let text = info.selectionText;
 
     // do not show menu entry when no text is selected
@@ -140,6 +144,7 @@ async function addMenuItems(menuItems, unicodeFontSettings = lastCachedUnicodeFo
         if (unicodeFontSettings.showReadableText) {
             menuText = browser.i18n.getMessage("menuReadableTextWrapper", [translatedMenuText, transformedText]);
         }
+        menuText = menuText.replaceAll("&", "&&");
 
         if (refreshMenu) {
             menus.update(transformationId, {

--- a/src/common/modules/UnicodeTransformationHandler.js
+++ b/src/common/modules/UnicodeTransformationHandler.js
@@ -53,6 +53,7 @@ export function getTransformationType(transformationId) {
 function capitalizeEachWord(text) {
     // Regular expression Unicode property escapes and lookbehind assertions require Firefox/Thunderbird 78
     // see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp#bcd:javascript.builtins.RegExp
+    // \p{Alphabetic}
     return text.replace(/(?<=^|\P{Alpha})\p{Alpha}\S*/gu, ([h, ...t]) => h.toLocaleUpperCase() + t.join(""));
 }
 
@@ -110,12 +111,13 @@ function toggleCase(atext) {
     let output = "";
 
     for (let letter of atext) {
-        const upper = letter.toLocaleUpperCase();
-        const lower = letter.toLocaleLowerCase();
-        if (letter === lower && letter !== upper) {
-            letter = upper;
-        } else if (letter === upper && letter !== lower) {
-            letter = lower;
+        // \p{Changes_When_Uppercased}
+        if (/\p{CWU}/u.test(letter)) {
+            letter = letter.toLocaleUpperCase();
+        }
+        // \p{Changes_When_Lowercased}
+        else if (/\p{CWL}/u.test(letter)) {
+            letter = letter.toLocaleLowerCase();
         }
         output += letter;
     }

--- a/src/content_scripts/autocorrect.js
+++ b/src/content_scripts/autocorrect.js
@@ -44,7 +44,7 @@ let longest = 0;
 
 // Regular expressions
 let symbolpatterns = null;
-// Do not autocorrect for these patterns
+// Exceptions, do not autocorrect for these patterns
 let antipatterns = null;
 
 // Thunderbird

--- a/src/content_scripts/autocorrect.js
+++ b/src/content_scripts/autocorrect.js
@@ -309,15 +309,16 @@ function autocorrect(event) {
         } else {
             // Convert fractions and mathematical constants to Unicode characters
             if (!output && fracts) {
-                // Numbers: https://regex101.com/r/7jUaSP/2
-                const numberRegex = /[0-9]+(\.[0-9]+)?$/;
+                // Numbers regular expression: https://regex101.com/r/7jUaSP/10
+                // Do not match version numbers: https://github.com/rugk/unicodify/issues/40
+                const numberRegex = /(?<!\.)\d+(?<fractionpart>\.\d+)?$/;
                 const previousText = value.slice(0, caretposition - 1);
                 const regexResult = numberRegex.exec(previousText);
-                if (regexResult) {
+                if (regexResult && insert !== ".") {
                     const text = value.slice(0, caretposition);
                     const aregexResult = numberRegex.exec(text);
                     if (!aregexResult) {
-                        const label = outputLabel(regexResult[0], regexResult[1]);
+                        const label = outputLabel(regexResult[0], regexResult.groups.fractionpart);
                         const index = firstDifferenceIndex(label, regexResult[0]);
                         if (index >= 0) {
                             insert = label.slice(index) + (event.keyCode === 13 ? "\n" : insert);

--- a/src/options/options.html
+++ b/src/options/options.html
@@ -53,17 +53,16 @@
 		</div>
 		<form>
 			<section>
-				<ul>
-					<h1 data-i18n="__MSG_titleUnicodeAutocorrection__">Unicode autocorrection</h1>
-					<span class="helper-text" data-i18n="__MSG_optionHelperTextAutocorrection__"  data-opt-i18n-keep-children>
-					You can configure the automatic corrections that are done when you are typing text here.<br>
-					All the autocorrections are done after typing the first nonmatching character following the character sequence, such as a space (␣). Press Backspace (⌫) to undo an autocorrection.
-					Only the quotes replacement is done immediately.
+				<h1 data-i18n="__MSG_titleUnicodeAutocorrection__">Unicode autocorrection</h1>
+				<span class="helper-text" data-i18n="__MSG_optionHelperTextAutocorrection__"  data-opt-i18n-keep-children>
+				You can configure the automatic corrections that are done when you are typing text here.<br>
+				All the autocorrections are done after typing the first nonmatching character following the character sequence, such as a space (␣). Press Backspace (⌫) to undo an autocorrection.
+				Only the quotes replacement is done immediately.
 				</span><br>
-					<span class="helper-text" data-i18n="__MSG_optionHelperTextAutocorrectionEmoji__"  data-opt-i18n-keep-children>
-					For Emoji autocorrection, including <code data-i18n="__MSG_optionHelperTextAutocorrectionEmojiColonsCode__">:colon:</code> shortcodes and Emoticons, please also try out our <a id="link-awesome-emoji" data-i18n="__MSG_optionHelperTextAutocorrectionEmojiLinkText__">🤩&nbsp;Awesome Emoji Picker</a> add-on.
-					</span>
-
+				<span class="helper-text" data-i18n="__MSG_optionHelperTextAutocorrectionEmoji__"  data-opt-i18n-keep-children>
+				For Emoji autocorrection, including <code data-i18n="__MSG_optionHelperTextAutocorrectionEmojiColonsCode__">:colon:</code> shortcodes and Emoticons, please also try out our <a id="link-awesome-emoji" data-i18n="__MSG_optionHelperTextAutocorrectionEmojiLinkText__">🤩&nbsp;Awesome Emoji Picker</a> add-on.
+				</span>
+				<ul>
 					<li>
 						<div class="line">
 							<input class="setting save-on-change" type="checkbox" id="autocorrectSymbols" data-optiongroup="autocorrect" name="autocorrectSymbols">
@@ -93,11 +92,11 @@
 
 			<!-- Remove "mobile-incompatible" once https://bugzilla.mozilla.org/show_bug.cgi?id=1595822 is fixed -->
 			<section class="mobile-incompatible">
-				<ul>
-					<h1 data-i18n="__MSG_titleContextMenu__">Context menu</h1>
-					<span class="helper-text" data-i18n="__MSG_optionHelperTextContextMenu__">Write, select text and choose the corresponding option in the context menu to quickly change the character style or capitalization.
-					This is useful on websites that do not support changing the font or text formatting.</span>
+				<h1 data-i18n="__MSG_titleContextMenu__">Context menu</h1>
+				<span class="helper-text" data-i18n="__MSG_optionHelperTextContextMenu__">Write, select text and choose the corresponding option in the context menu to quickly change the character style or capitalization.
+				This is useful on websites that do not support changing the font or text formatting.</span>
 
+				<ul>
 					<li>
 						<div class="line">
 							<input class="setting save-on-change" type="checkbox" id="changeFont" data-optiongroup="unicodeFont" name="changeFont">


### PR DESCRIPTION
* Fixes #40
* Improved performance. 
    * Improved toggle case performance by not both upper and lowercaseing every letter.
    * Replaced `for` loops with `map()`.
* Partially implemented https://github.com/rugk/unicodify/pull/21#issuecomment-822756761.
* ~The `<all_urls>` permission is not needed for Thunderbird. The `compose` permission replaces it.~ While it is not needed for the compose window, it is needed when viewing webpages in TB, so I reverted this change.
* More minor bug fixes:
    * The ampersand is a special character in the menu titles and needs to be escaped for the live previews.
    * Fixed errors when context menu is opened with non-editable text selected.
* Fixed indentation on options page. The headings should not have been in the list. (I messed this up in #2.)
* Minor ESLint fix.
* Use the localized extension name in Chrome (see #45). 
* Removed use of deprecated [`substr()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr#browser_compatibility) method.