### PR TITLE
Fix wrong parameter usage leading to tip showing problem

### DIFF
--- a/src/common/modules/data/Tips.js
+++ b/src/common/modules/data/Tips.js
@@ -103,7 +103,7 @@ const tipArray = [
         },
         randomizeDisplay: false,
         text: "tipYouLikeAddon",
-            actionButton: {
+        actionButton: {
             text: "tipYouLikeAddonButton",
             action: ""
         },

--- a/src/common/modules/data/Tips.js
+++ b/src/common/modules/data/Tips.js
@@ -103,12 +103,12 @@ const tipArray = [
         },
         randomizeDisplay: false,
         text: "tipYouLikeAddon",
-        actionButton: {
+            actionButton: {
             text: "tipYouLikeAddonButton",
             action: ""
         },
         showTip: async (tipSpec, thisTipConfig) => {
-            thisTipConfig.actionButton.action = await getBrowserValue({
+            tipSpec.actionButton.action = await getBrowserValue({
                 firefox: "https://addons.mozilla.org/firefox/addon/unicodify-text-transformer/reviews/?utm_source=unicodify-addon&utm_medium=addon&utm_content=unicodify-addon-tips-tipYouLikeAddon&utm_campaign=unicodify-addon-tips",
                 thunderbird: "https://addons.thunderbird.net/thunderbird/addon/unicodify-text-transformer/reviews/?utm_source=unicodify-addon&utm_medium=addon&utm_content=unicodify-addon-tips-awesomeIcons&utm_campaign=unicodify-addon-tips",
                 chrome: "https://chrome.google.com/webstore/detail/unicodify-text-transformer/#...",
@@ -131,8 +131,8 @@ const tipArray = [
             text: "tipAwesomeIconsButton",
             action: ""
         },
-        showTip: async (tipSpec, thisTipConfig) => {
-            thisTipConfig.actionButton.action = await getBrowserValue({
+        showTip: async (tipSpec) => {
+            tipSpec.actionButton.action = await getBrowserValue({
                 firefox: "https://addons.mozilla.org/firefox/addon/awesome-emoji-picker/?utm_source=unicodify-addon&utm_medium=addon&utm_content=unicodify-addon-tips-awesomeIcons&utm_campaign=unicodify-addon-tips",
                 thunderbird: "https://addons.thunderbird.net/thunderbird/addon/awesome-emoji-picker/reviews/?utm_source=unicodify-addon&utm_medium=addon&utm_content=unicodify-addon-tips-awesomeIcons&utm_campaign=unicodify-addon-tips",
                 chrome: "https://chrome.google.com/webstore/detail/awesome-emoji-picker/",


### PR DESCRIPTION
The affected tips could not be shown due to a TypeException as it tries to acess a non-defined property.

This is a stupid error of course, that should have been catched earlier...
 
Fixes https://github.com/rugk/unicodify/issues/46

----

I tested it and as you can see in the screenshot, it works now…
Really a facepalm issue :see_no_evil: :man_facepalming: :sweat_smile: 

![image](https://user-images.githubusercontent.com/11966684/129268773-366984c0-9719-487f-8004-ab28e403a68b.png)
