### PR TITLE
Create a new issue template for Thunderbird

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report_thunderbird
+++ b/.github/ISSUE_TEMPLATE/bug_report_thunderbird
@@ -1,0 +1,40 @@
+---
+name: Bug report (Thunderbird-only)
+about: Create a report to help us improve. Please use this if your bug is _only_ about THunderbird.
+title: ''
+labels: bug
+assignees: @tdulcet
+
+---
+
+## Bug description
+<!-- A short summary of the issue. You can also explain how it affected you or explain some background of the story. -->
+
+## Steps to reproduce
+<!-- Describe what steps you did/can do to reproduce the problem. Also mention if it is not always reproducible. If applicable, add screenshots to help explain your problem. -->
+
+1. 
+2. 
+3. 
+
+### Actual behavior
+<!-- The behavior you experienced. -->
+
+### Expected behavior
+<!-- A clear and concise description of what you expected to happen. -->
+
+## Reproducibility on other systems
+* [ ] Issue is reproducible in Firefox
+      **Note:** If so, please consider switching your issue template to the general bug template.
+
+<!-- If applicable, explain the differing behaviour here in detail and/or add screenshots. -->
+
+## System
+<!-- Add some information about your system. You can omit values if you think they are really not necessary. -->
+
+Operating system and version: 
+Thunderbird version: Thunderbird 
+Add-on version: 
+
+## Possible solution
+<!-- Add references to other issues/docs/websites here or look into the code to find the potential causes of the problem or how to fix it. Omit this, if you don't know what to write here. -->

--- a/.github/ISSUE_TEMPLATE/bug_report_thunderbird
+++ b/.github/ISSUE_TEMPLATE/bug_report_thunderbird
@@ -2,7 +2,7 @@
 name: Bug report (Thunderbird-only)
 about: Create a report to help us improve. Please use this if your bug is _only_ about THunderbird.
 title: ''
-labels: bug
+labels: bug, Thunderbird
 assignees: @tdulcet
 
 ---


### PR DESCRIPTION
@tdulcet I hope it's okay if I assign you to Thunderbird-issues (automatically), given you have more experience there and also did the releases in the past.

If not, we can obviously change that.