### PR TITLE
Added notifications on install/update and exit survey on uninstall

### DIFF
--- a/assets/texts/en/atnDescription.html
+++ b/assets/texts/en/atnDescription.html
@@ -4,7 +4,7 @@ Additionally, you can convert text into more than 20 different font styles and c
 You can enable and disable any features in the options and adjust more settings regarding the behavior of the add-on.
 
 
-⚠️ Note that context menu does <strong>NOT</strong> currently work in Thunderbird's compose body because of <a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1716976">Bug 1716976</a>.
+⚠️ This extension requires at least Thunderbird 111 for the context menu to work in the compose body due to <a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1716976">Bug 1716976</a>.
 
 <b>Convert text to any style you want!</b>
 

--- a/scripts/manifests/chromemanifest.json
+++ b/scripts/manifests/chromemanifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 2,
   "name": "__MSG_extensionName__",
   "short_name": "__MSG_extensionNameShort__",
-  "version": "0.5",
+  "version": "0.6",
   "author": "Teal Dulcet, rugk",
 
   "description": "__MSG_extensionDescription__",

--- a/scripts/manifests/chromemanifest.json
+++ b/scripts/manifests/chromemanifest.json
@@ -44,6 +44,7 @@
     "storage",
     "<all_urls>",
     "tabs",
-    "contextMenus"
+    "contextMenus",
+    "notifications"
   ]
 }

--- a/scripts/manifests/dev.json
+++ b/scripts/manifests/dev.json
@@ -38,7 +38,8 @@
     "storage",
     "<all_urls>",
     "contextMenus",
-    "tabs"
+    "tabs",
+    "notifications"
   ],
 
   "applications": {

--- a/scripts/manifests/dev.json
+++ b/scripts/manifests/dev.json
@@ -2,7 +2,7 @@
   "manifest_version": 2,
   "name": "Unicodify DEV VERSION",
   "short_name": "__MSG_extensionNameShort__",
-  "version": "0.5",
+  "version": "0.6",
   "author": "Teal Dulcet, rugk",
 
   "description": "__MSG_extensionDescription__",
@@ -42,7 +42,7 @@
     "notifications"
   ],
 
-  "applications": {
+  "browser_specific_settings": {
     "gecko": {
       "id": "unicodify@rugk.github.io",
       "strict_min_version": "87.0"

--- a/scripts/manifests/firefox.json
+++ b/scripts/manifests/firefox.json
@@ -37,7 +37,8 @@
     "storage",
     "<all_urls>",
     "menus",
-    "tabs"
+    "tabs",
+    "notifications"
   ],
   "applications": {
     "gecko": {

--- a/scripts/manifests/firefox.json
+++ b/scripts/manifests/firefox.json
@@ -2,7 +2,7 @@
   "manifest_version": 2,
   "name": "__MSG_extensionName__",
   "short_name": "__MSG_extensionNameShort__",
-  "version": "0.5",
+  "version": "0.6",
   "author": "Teal Dulcet, rugk",
 
   "description": "__MSG_extensionDescription__",
@@ -40,7 +40,7 @@
     "tabs",
     "notifications"
   ],
-  "applications": {
+  "browser_specific_settings": {
     "gecko": {
       "id": "unicodify@rugk.github.io",
       "strict_min_version": "87.0"

--- a/scripts/manifests/thunderbirdmanifest.json
+++ b/scripts/manifests/thunderbirdmanifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 2,
   "name": "__MSG_extensionName__",
   "short_name": "__MSG_extensionNameShort__",
-  "version": "0.5.2",
+  "version": "0.6",
   "author": "Teal Dulcet, rugk",
 
   "description": "__MSG_extensionDescription__",
@@ -44,7 +44,7 @@
     "clipboardWrite"
   ],
 
-  "applications": {
+  "browser_specific_settings": {
     "gecko": {
       "id": "unicodify@rugk.github.io",
       "strict_min_version": "91.0"

--- a/src/background/background.html
+++ b/src/background/background.html
@@ -8,6 +8,7 @@ See also https://discourse.mozilla.org/t/using-es6-modules-in-background-scripts
 		<meta charset="utf-8">
 		<!-- async currently disabled, because of https://bugzilla.mozilla.org/show_bug.cgi?id=1506464 -->
 		<script type="application/javascript" src="../browser-polyfill.js"></script>
+		<script src="./modules/InstallUpgrade.js" type="module" charset="utf-8"></script>
 		<script async src="background.js" type="module" charset="utf-8"></script>
 	</head>
 	<body>

--- a/src/background/modules/AutocorrectHandler.js
+++ b/src/background/modules/AutocorrectHandler.js
@@ -13,6 +13,9 @@ const settings = {
     fracts: null
 };
 
+// Leaf node
+const LEAF = Symbol("leaf");
+
 let autocorrections = {};
 
 // Longest autocorrection
@@ -43,8 +46,9 @@ function createRegEx(tree) {
         if (char) {
             const escaptedChar = char.replace(regExSpecialChars, "\\$&");
 
-            if (!("" in tree[char] && Object.keys(tree[char]).length === 1)) {
-                const recurse = createRegEx(tree[char]);
+            const atree = tree[char];
+            if (!(LEAF in atree && Object.keys(atree).length === 0)) {
+                const recurse = createRegEx(atree);
                 alternatives.push(recurse + escaptedChar);
             } else {
                 characterClass.push(escaptedChar);
@@ -58,7 +62,7 @@ function createRegEx(tree) {
 
     let result = alternatives.length === 1 ? alternatives[0] : `(?:${alternatives.join("|")})`;
 
-    if ("" in tree) {
+    if (LEAF in tree) {
         if (characterClass.length || alternatives.length > 1) {
             result += "?";
         } else {
@@ -91,7 +95,7 @@ function createTree(arr) {
         }
 
         // Leaf node
-        temp[""] = true;
+        temp[LEAF] = true;
     }
 
     Object.freeze(tree);

--- a/src/background/modules/AutocorrectHandler.js
+++ b/src/background/modules/AutocorrectHandler.js
@@ -104,6 +104,7 @@ function createTree(arr) {
  * @returns {void}
  */
 function applySettings() {
+    const start = performance.now();
     autocorrections = {};
 
     // Add all symbols to our autocorrections map, we want to replace
@@ -158,6 +159,8 @@ function applySettings() {
 
     symbolpatterns = new RegExp(`(${symbolpatterns})$`, "u");
     antipatterns = new RegExp(`(${antipatterns})$`, "u");
+    const end = performance.now();
+    console.log(`The new autocorrect settings were applied in ${end - start} ms.`);
 }
 
 /**

--- a/src/background/modules/ContextMenu.js
+++ b/src/background/modules/ContextMenu.js
@@ -32,7 +32,7 @@ function fallback(text, fieldId) {
         [
             pasteSymbol,
             fieldName
-        ]);
+        ], true);
 }
 
 /**

--- a/src/background/modules/InstallUpgrade.js
+++ b/src/background/modules/InstallUpgrade.js
@@ -66,4 +66,5 @@ function handleInstalled(details) {
 
 browser.runtime.onInstalled.addListener(handleInstalled);
 
-browser.runtime.setUninstallURL("https://forms.gle/P8ThPXAvbGEkshYDA");
+// Previous exit survey: https://forms.gle/P8ThPXAvbGEkshYDA
+browser.runtime.setUninstallURL("https://cryptpad.fr/form/#/2/form/view/TyXGnnNjCOo+iC2qrvPzfO8NMK4jMg3pRKxL0mrYNs8/");

--- a/src/background/modules/InstallUpgrade.js
+++ b/src/background/modules/InstallUpgrade.js
@@ -43,12 +43,14 @@ function handleInstalled(details) {
     case "update":
         if (Notifications.SEND) {
             const [major, minor, patch = 0] = details.previousVersion.split(".").map((x) => Number.parseInt(x, 10));
+            // The autocorrection feature was disabled by default in version 0.5.1
+            const disabled = major === 0 && (minor < 5 || minor === 5 && patch === 0);
             // TODO: This will need to be localized
             browser.notifications.create({
                 type: "basic",
                 iconUrl: browser.runtime.getURL("icons/icon.svg"),
                 title: `✨ ${manifest.name} updated`,
-                message: `The “${manifest.name}” add-on has been updated to version ${manifest.version}. Click to see the release notes.\n\nThe experimental Unicode autocorrection feature ${major === 0 && (minor < 5 || minor === 5 && patch === 0) ? "has been disabled by default" : "was disabled by default in version 0.5.1"}. Open the options/preferences page to reenable.`
+                message: `The “${manifest.name}” add-on has been updated to version ${manifest.version}. Click to see the release notes.\n\nThe experimental Unicode autocorrection feature ${disabled ? "has been disabled by default" : "was disabled by default in version 0.5.1"}. Open the options/preferences page to reenable.`
             }).then(async (notificationId) => {
                 const url = await getBrowserValue({
                     firefox: `https://addons.mozilla.org/firefox/addon/unicodify-text-transformer/versions/${manifest.version}`,

--- a/src/background/modules/InstallUpgrade.js
+++ b/src/background/modules/InstallUpgrade.js
@@ -37,7 +37,7 @@ function handleInstalled(details) {
     const manifest = browser.runtime.getManifest();
     switch (details.reason) {
     case "install":
-        // TODO: This will need to be localized
+        // TODO(to: 'rugk'): This will need to be localized
         Notifications.showNotification(`🎉 ${manifest.name} installed`, `Thank you for installing the “${manifest.name}” add-on!\nVersion: ${manifest.version}\n\nOpen the options/preferences page to configure this extension.`);
         break;
     case "update":
@@ -45,7 +45,7 @@ function handleInstalled(details) {
             const [major, minor, patch = 0] = details.previousVersion.split(".").map((x) => Number.parseInt(x, 10));
             // The autocorrection feature was disabled by default in version 0.5.1
             const disabled = major === 0 && (minor < 5 || minor === 5 && patch === 0);
-            // TODO: This will need to be localized
+            // TODO(to: 'rugk'): This will need to be localized
             browser.notifications.create({
                 type: "basic",
                 iconUrl: browser.runtime.getURL("icons/icon.svg"),

--- a/src/background/modules/InstallUpgrade.js
+++ b/src/background/modules/InstallUpgrade.js
@@ -1,0 +1,67 @@
+/**
+ * Upgrades user data on installation of new updates.
+ *
+ * @module InstallUpgrade
+ */
+
+import * as Notifications from "/common/modules/Notifications.js";
+import { getBrowserValue } from "/common/modules/BrowserCompat.js";
+
+
+const notifications = new Map();
+
+
+browser.notifications.onClicked.addListener((notificationId) => {
+    const url = notifications.get(notificationId);
+
+    if (url) {
+        browser.tabs.create({ url });
+    }
+});
+
+browser.notifications.onClosed.addListener((notificationId) => {
+    notifications.delete(notificationId);
+});
+
+/**
+ * Checks whether an upgrade is needed.
+ *
+ * @see {@link https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/runtime/onInstalled}
+ * @private
+ * @param {Object} details
+ * @returns {void}
+ */
+function handleInstalled(details) {
+    console.log(details);
+
+    const manifest = browser.runtime.getManifest();
+    switch (details.reason) {
+    case "install":
+        // TODO: This will need to be localized
+        Notifications.showNotification(`🎉 ${manifest.name} installed`, `Thank you for installing the “${manifest.name}” add-on!\nVersion: ${manifest.version}\n\nOpen the options/preferences page to configure this extension.`);
+        break;
+    case "update":
+        if (Notifications.SEND) {
+            const [major, minor, patch = 0] = details.previousVersion.split(".").map((x) => Number.parseInt(x, 10));
+            // TODO: This will need to be localized
+            browser.notifications.create({
+                type: "basic",
+                iconUrl: browser.runtime.getURL("icons/icon.svg"),
+                title: `✨ ${manifest.name} updated`,
+                message: `The “${manifest.name}” add-on has been updated to version ${manifest.version}. Click to see the release notes.\n\nThe experimental Unicode autocorrection feature ${major === 0 && (minor < 5 || minor === 5 && patch === 0) ? "has been disabled by default" : "was disabled by default in version 0.5.1"}. Open the options/preferences page to reenable.`
+            }).then(async (notificationId) => {
+                const url = await getBrowserValue({
+                    firefox: `https://addons.mozilla.org/firefox/addon/unicodify-text-transformer/versions/${manifest.version}`,
+                    thunderbird: `https://addons.thunderbird.net/thunderbird/addon/unicodify-text-transformer/versions/${manifest.version}`,
+                    chrome: "" // The Chrome Web Store does not show release notes
+                }) || `https://github.com/rugk/unicodify/releases/v${manifest.version}`;
+                notifications.set(notificationId, url);
+            });
+        }
+        break;
+    }
+}
+
+browser.runtime.onInstalled.addListener(handleInstalled);
+
+browser.runtime.setUninstallURL("https://forms.gle/P8ThPXAvbGEkshYDA");

--- a/src/common/modules/Notifications.js
+++ b/src/common/modules/Notifications.js
@@ -16,20 +16,20 @@ const ICON = browser.runtime.getManifest().icons[32];
 export let SEND = true;
 
 /**
- * Show a notification.
+ * Show a notification. If the notification is optional, the user can disable it with an add-on setting. If it is required, the notification will always be shown. Use the latter notification type only sparsely, e.g. for user-initiated actions providing feedback to the user.
  *
  * @public
  * @param {string} title the title
  * @param {string} content the message content
  * @param {string[] | string} [substitutions] the message parameters to pass for i18n.getMessage
- * @param {boolean} [send]
+ * @param {boolean} [requiredNotification]
  * @returns {void}
  * @see {@link https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/notifications/create}
  */
-export function showNotification(title, content, substitutions, send) {
+export function showNotification(title, content, substitutions, requiredNotification) {
     console.info("Showing notification:", title, content);
 
-    if (!SEND && !send) {
+    if (!SEND && !requiredNotification) {
         return;
     }
 

--- a/src/common/modules/Notifications.js
+++ b/src/common/modules/Notifications.js
@@ -22,13 +22,14 @@ export let SEND = true;
  * @param {string} title the title
  * @param {string} content the message content
  * @param {string[] | string} [substitutions] the message parameters to pass for i18n.getMessage
+ * @param {boolean} [send]
  * @returns {void}
  * @see {@link https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/notifications/create}
  */
-export function showNotification(title, content, substitutions) {
+export function showNotification(title, content, substitutions, send) {
     console.info("Showing notification:", title, content);
 
-    if (!SEND) {
+    if (!SEND && !send) {
         return;
     }
 

--- a/src/common/modules/Notifications.js
+++ b/src/common/modules/Notifications.js
@@ -16,13 +16,15 @@ const ICON = browser.runtime.getManifest().icons[32];
 export let SEND = true;
 
 /**
- * Show a notification. If the notification is optional, the user can disable it with an add-on setting. If it is required, the notification will always be shown. Use the latter notification type only sparsely, e.g. for user-initiated actions providing feedback to the user.
+ * Show a notification.
+ *
+ * If the notification is optional, the user can disable it with an add-on setting. If it is required, the notification will always be shown. Use the latter notification type only sparsely, e.g. for user-initiated actions providing feedback to the user.
  *
  * @public
  * @param {string} title the title
  * @param {string} content the message content
  * @param {string[] | string} [substitutions] the message parameters to pass for i18n.getMessage
- * @param {boolean} [requiredNotification]
+ * @param {boolean} [requiredNotification=false]
  * @returns {void}
  * @see {@link https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/notifications/create}
  */

--- a/src/common/modules/data/BrowserCommunicationTypes.js
+++ b/src/common/modules/data/BrowserCommunicationTypes.js
@@ -16,5 +16,6 @@ export const COMMUNICATION_MESSAGE_TYPE = Object.freeze({
     AUTOCORRECT_BACKGROUND: "autocorrectBackground",
     AUTOCORRECT_CONTENT: "autocorrectContent",
     UNICODE_FONT: "unicodeFont",
-    UPDATE_CONTEXT_MENU: "updateContextMenu"
+    UPDATE_CONTEXT_MENU: "updateContextMenu",
+    NOTIFICATIONS: "notifications"
 });

--- a/src/common/modules/data/DefaultSettings.js
+++ b/src/common/modules/data/DefaultSettings.js
@@ -19,13 +19,16 @@ const defaultSettings = {
         enabled: false,
         autocorrectSymbols: true,
         autocorrectUnicodeQuotes: true,
-        autocorrectUnicodeFracts: true,
+        autocorrectUnicodeFracts: true
     },
     unicodeFont: {
         changeFont: true,
         changeCase: true,
         showReadableText: false,
         livePreview: false
+    },
+    notifications: {
+        send: true
     }
 };
 

--- a/src/content_scripts/autocorrect.js
+++ b/src/content_scripts/autocorrect.js
@@ -146,7 +146,7 @@ function countChars(str) {
 
     for (const s of split) {
         // removing the variation selectors
-        count += Array.from(s.split(/[\uFE00-\uFE0F]/u).join("")).length;
+        count += Array.from(s.removeAll(/[\uFE00-\uFE0F]/gu)).length;
     }
 
     return count;
@@ -186,7 +186,7 @@ function deleteCaret(target, atext) {
 
 /**
  * Convert fractions and constants to Unicode characters.
- * Adapted from: https://github.com/tdulcet/Tables-and-Graphs/blob/master/graphs.hpp
+ * Adapted from: https://github.com/tdulcet/Table-and-Graph-Libs/blob/master/graphs.hpp
  *
  * @param {string} anumber
  * @param {string} afraction
@@ -417,11 +417,11 @@ function handleResponse(message, sender) {
     // console.log(message);
 
     if (enabled) {
-        window.addEventListener("beforeinput", undoAutocorrect, true);
-        window.addEventListener("beforeinput", autocorrect, true);
+        addEventListener("beforeinput", undoAutocorrect, true);
+        addEventListener("beforeinput", autocorrect, true);
     } else {
-        window.removeEventListener("beforeinput", undoAutocorrect, true);
-        window.removeEventListener("beforeinput", autocorrect, true);
+        removeEventListener("beforeinput", undoAutocorrect, true);
+        removeEventListener("beforeinput", autocorrect, true);
     }
 }
 

--- a/src/content_scripts/autocorrect.js
+++ b/src/content_scripts/autocorrect.js
@@ -146,7 +146,7 @@ function countChars(str) {
 
     for (const s of split) {
         // removing the variation selectors
-        count += Array.from(s.removeAll(/[\uFE00-\uFE0F]/gu)).length;
+        count += Array.from(s.replaceAll(/[\uFE00-\uFE0F]/gu, "")).length;
     }
 
     return count;

--- a/src/content_scripts/autocorrect.js
+++ b/src/content_scripts/autocorrect.js
@@ -196,39 +196,43 @@ function outputLabel(anumber, afraction) {
     let output = false;
 
     const number = Number.parseFloat(anumber);
-    let intpart = Math.trunc(number);
-    const fractionpart = afraction ? Number.parseFloat(afraction) : Math.abs(number % 1);
+    const n = Math.abs(number);
 
     let str = "";
 
-    for (const fraction in fractions) {
-        if (Math.abs(fractionpart - fractions[fraction]) < Number.EPSILON) {
-            if (intpart !== 0) {
-                str += intpart;
-            }
+    if (n <= Number.MAX_SAFE_INTEGER) {
+        let intpart = Math.trunc(number);
+        const fractionpart = afraction ? Number.parseFloat(afraction) : Math.abs(number % 1);
 
-            str += fraction;
-
-            output = true;
-            break;
-        }
-    }
-
-    if (Math.abs(number) >= Number.EPSILON && !output) {
-        for (const constant in constants) {
-            if (!output && number % constants[constant] === 0) {
-                intpart = number / constants[constant];
-
-                if (intpart === -1) {
-                    str += "-";
-                } else if (intpart !== 1) {
+        for (const [fraction, value] of Object.entries(fractions)) {
+            if (Math.abs(fractionpart - value) <= Number.EPSILON * n) {
+                if (intpart !== 0) {
                     str += intpart;
                 }
 
-                str += constant;
+                str += fraction;
 
                 output = true;
                 break;
+            }
+        }
+
+        if (n > Number.EPSILON && !output) {
+            for (const [constant, value] of Object.entries(constants)) {
+                if (!output && number % value <= Number.EPSILON * n) {
+                    intpart = number / value;
+
+                    if (intpart === -1) {
+                        str += "-";
+                    } else if (intpart !== 1) {
+                        str += intpart;
+                    }
+
+                    str += constant;
+
+                    output = true;
+                    break;
+                }
             }
         }
     }

--- a/src/content_scripts/autocorrect.js
+++ b/src/content_scripts/autocorrect.js
@@ -206,7 +206,9 @@ function outputLabel(anumber, afraction) {
 
         for (const [fraction, value] of Object.entries(fractions)) {
             if (Math.abs(fractionpart - value) <= Number.EPSILON * n) {
-                if (intpart !== 0) {
+                if (intpart === 0 && number < 0) {
+                    str += "-";
+                } else if (intpart !== 0) {
                     str += intpart;
                 }
 

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -38,7 +38,8 @@
     "storage",
     "<all_urls>",
     "contextMenus",
-    "tabs"
+    "tabs",
+    "notifications"
   ],
 
   "applications": {

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 2,
   "name": "Unicodify DEV VERSION",
   "short_name": "__MSG_extensionNameShort__",
-  "version": "0.5",
+  "version": "0.6",
   "author": "Teal Dulcet, rugk",
 
   "description": "__MSG_extensionDescription__",
@@ -42,7 +42,7 @@
     "notifications"
   ],
 
-  "applications": {
+  "browser_specific_settings": {
     "gecko": {
       "id": "unicodify@rugk.github.io",
       "strict_min_version": "87.0"

--- a/src/options/modules/CustomOptionTriggers.js
+++ b/src/options/modules/CustomOptionTriggers.js
@@ -52,6 +52,23 @@ function applyUnicodeFontSettings(optionValue) {
 }
 
 /**
+ * Apply the new Notification settings.
+ *
+ * @private
+ * @param  {Object} optionValue
+ * @param  {string} [option]
+ * @param  {Object} [event]
+ * @returns {void}
+ */
+function applyNotificationSettings(optionValue) {
+    // trigger update for current session
+    browser.runtime.sendMessage({
+        type: COMMUNICATION_MESSAGE_TYPE.NOTIFICATIONS,
+        optionValue: optionValue
+    });
+}
+
+/**
  * Binds the triggers.
  *
  * This is basically the "init" method.
@@ -62,6 +79,7 @@ export function registerTrigger() {
     // update slider status
     AutomaticSettings.Trigger.registerSave("autocorrect", applyAutocorrectPermissions);
     AutomaticSettings.Trigger.registerSave("unicodeFont", applyUnicodeFontSettings);
+    AutomaticSettings.Trigger.registerSave("notifications", applyNotificationSettings);
 
     // handle loading of options correctly
     AutomaticSettings.Trigger.registerAfterLoad(AutomaticSettings.Trigger.RUN_ALL_SAVE_TRIGGER);

--- a/src/options/options.html
+++ b/src/options/options.html
@@ -154,6 +154,19 @@
 				</ul>
 			</section>
 
+			<section>
+				<h1>Notifications</h1>
+
+				<ul>
+					<li>
+						<div class="line">
+							<input class="setting save-on-change" type="checkbox" id="send" data-optiongroup="notifications" name="send">
+							<label for="send">Display Desktop notifications</label>
+						</div>
+					</li>
+				</ul>
+			</section>
+
 			<div>
 				<hr /><br />
 				<button data-i18n="__MSG_optionsResetButton__" type="button" id="resetButton">Reset all settings to defaults</button>


### PR DESCRIPTION
* Added notifications on install and update.
    * Clicking the update notification will open the release notes/changelog on AMO/ATN.
* Added option to disable desktop notifications.
* Added exit survey on uninstall.
    * The draft exit survey is currently here: https://forms.gle/P8ThPXAvbGEkshYDA. Once you approve it, I can move it to https://cryptpad.fr/form/ as requested.
    * **Edit**: It is now on CryptPad: https://cryptpad.fr/form/#/2/form/view/TyXGnnNjCOo+iC2qrvPzfO8NMK4jMg3pRKxL0mrYNs8/
* Improved support for large numbers when converting fractions and constants to Unicode characters.
* Updated to generate optimized RegExes from autocorrections using a [Trie tree](https://en.wikipedia.org/wiki/Trie).
    * This should both improve the performance of the autocorrect feature and reduce memory usage.
* Bumped the version to 0.6

![image](https://user-images.githubusercontent.com/15305150/196928790-6033fd23-8598-4a90-8747-ff901e2c7d95.png)
![image](https://user-images.githubusercontent.com/15305150/196929040-24544f7a-e197-4814-88c2-fa521b6aaae6.png)

Per our discussion in https://github.com/TinyWebEx/RandomTips/issues/9, the `Notifications.js` module will need to be refactored to support clicking on the notifications. For now I added this functionality to the new `InstallUpgrade.js` module (adapted from the Awesome Emoji Picker) to show the necessarily changes.

TODO:

- [ ] Localize new strings. @rugk 
- [ ] Refactor Notifications module as needed.
- [x] Move exit survey to https://cryptpad.fr/form/.
- [ ] Update the `permissions.md` file.

I believe this along with #72 should finally allow us release v1.0.