### PR TITLE
Removed use of `tabs.executeScript()` and updated manifest files

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,7 +1,7 @@
 {
     "root": true,
     "parserOptions": {
-        "ecmaVersion": 12,
+        "ecmaVersion": 14,
         "sourceType": "module",
         "ecmaFeatures": {
             "impliedStrict": true
@@ -10,7 +10,7 @@
     "env": {
         "browser": true,
         "webextensions": true,
-        "es2021": true
+        "es2023": true
     },
     "extends": "eslint:recommended",
     "rules": {

--- a/scripts/manifests/chromemanifest.json
+++ b/scripts/manifests/chromemanifest.json
@@ -9,13 +9,12 @@
   "homepage_url": "https://github.com/rugk/unicodify",
 
   "options_ui": {
-    "page": "options/options.html",
-    "browser_style": true,
-    "chrome_style": true
+    "page": "options/options.html"
   },
 
   "background": {
-    "page": "background/background.html"
+    "scripts": ["browser-polyfill.js", "background/modules/InstallUpgrade.js", "background/background.js"],
+    "type": "module"
   },
   "content_scripts": [
     {

--- a/scripts/manifests/dev.json
+++ b/scripts/manifests/dev.json
@@ -9,12 +9,12 @@
   "homepage_url": "https://github.com/rugk/unicodify",
 
   "options_ui": {
-    "page": "options/options.html",
-    "browser_style": true
+    "page": "options/options.html"
   },
 
   "background": {
-    "page": "background/background.html"
+    "scripts": ["background/modules/InstallUpgrade.js", "background/background.js"],
+    "type": "module"
   },
   "content_scripts": [
     {
@@ -45,7 +45,7 @@
   "browser_specific_settings": {
     "gecko": {
       "id": "unicodify@rugk.github.io",
-      "strict_min_version": "87.0"
+      "strict_min_version": "112.0"
     }
   }
 }

--- a/scripts/manifests/firefox.json
+++ b/scripts/manifests/firefox.json
@@ -9,12 +9,12 @@
   "homepage_url": "https://github.com/rugk/unicodify",
 
   "options_ui": {
-    "page": "options/options.html",
-    "browser_style": true
+    "page": "options/options.html"
   },
 
   "background": {
-    "page": "background/background.html"
+    "scripts": ["background/modules/InstallUpgrade.js", "background/background.js"],
+    "type": "module"
   },
   "content_scripts": [
     {
@@ -43,7 +43,7 @@
   "browser_specific_settings": {
     "gecko": {
       "id": "unicodify@rugk.github.io",
-      "strict_min_version": "87.0"
+      "strict_min_version": "112.0"
     }
   }
 }

--- a/scripts/manifests/thunderbirdmanifest.json
+++ b/scripts/manifests/thunderbirdmanifest.json
@@ -9,12 +9,12 @@
   "homepage_url": "https://github.com/rugk/unicodify",
 
   "options_ui": {
-    "page": "options/options.html",
-    "browser_style": true
+    "page": "options/options.html"
   },
 
   "background": {
-    "page": "background/background.html"
+    "scripts": ["background/modules/InstallUpgrade.js", "background/background.js"],
+    "type": "module"
   },
   "content_scripts": [
     {
@@ -47,7 +47,7 @@
   "browser_specific_settings": {
     "gecko": {
       "id": "unicodify@rugk.github.io",
-      "strict_min_version": "91.0"
+      "strict_min_version": "112.0"
     }
   }
 }

--- a/src/background/background.html
+++ b/src/background/background.html
@@ -7,7 +7,7 @@ See also https://discourse.mozilla.org/t/using-es6-modules-in-background-scripts
 	<head>
 		<meta charset="utf-8">
 		<!-- async currently disabled, because of https://bugzilla.mozilla.org/show_bug.cgi?id=1506464 -->
-		<script type="application/javascript" src="../browser-polyfill.js"></script>
+		<script src="../browser-polyfill.js" type="module"></script>
 		<script src="./modules/InstallUpgrade.js" type="module" charset="utf-8"></script>
 		<script async src="background.js" type="module" charset="utf-8"></script>
 	</head>

--- a/src/background/modules/AutocorrectHandler.js
+++ b/src/background/modules/AutocorrectHandler.js
@@ -213,8 +213,8 @@ function sendSettings(autocorrect) {
                     enabled: settings.enabled,
                     quotes: settings.quotes,
                     fracts: settings.fracts,
-                    autocorrections: autocorrections,
-                    longest: longest,
+                    autocorrections,
+                    longest,
                     symbolpatterns: IS_CHROME ? symbolpatterns.source : symbolpatterns,
                     antipatterns: IS_CHROME ? antipatterns.source : antipatterns
                 }
@@ -260,8 +260,8 @@ browser.runtime.onMessage.addListener((message) => {
             enabled: settings.enabled,
             quotes: settings.quotes,
             fracts: settings.fracts,
-            autocorrections: autocorrections,
-            longest: longest,
+            autocorrections,
+            longest,
             symbolpatterns: IS_CHROME ? symbolpatterns.source : symbolpatterns,
             antipatterns: IS_CHROME ? antipatterns.source : antipatterns
         };

--- a/src/background/modules/ContextMenu.js
+++ b/src/background/modules/ContextMenu.js
@@ -61,10 +61,10 @@ function handleMenuChoosen(info, tab) {
         return;
     }
 
-    browser.tabs.executeScript(tab.id, {
-        code: `insertIntoPage(${JSON.stringify(output)});`,
-        frameId: info.frameId
-    });
+    browser.tabs.sendMessage(tab.id, {
+        type: COMMUNICATION_MESSAGE_TYPE.INSERT,
+        text: output
+    }, { frameId: info.frameId });
 }
 
 /**

--- a/src/common/modules/Notifications.js
+++ b/src/common/modules/Notifications.js
@@ -41,7 +41,7 @@ export function showNotification(title, content, substitutions, requiredNotifica
     browser.notifications.create({
         type: "basic",
         iconUrl: browser.runtime.getURL(ICON),
-        title: title,
+        title,
         message: content
     });
 }
@@ -59,7 +59,7 @@ async function init() {
 
 init();
 
-BrowserCommunication.addListener(COMMUNICATION_MESSAGE_TYPE.NOTIFICATIONS, async (request) => {
+BrowserCommunication.addListener(COMMUNICATION_MESSAGE_TYPE.NOTIFICATIONS, (request) => {
     const notifications = request.optionValue;
 
     SEND = notifications.send;

--- a/src/common/modules/data/BrowserCommunicationTypes.js
+++ b/src/common/modules/data/BrowserCommunicationTypes.js
@@ -17,5 +17,6 @@ export const COMMUNICATION_MESSAGE_TYPE = Object.freeze({
     AUTOCORRECT_CONTENT: "autocorrectContent",
     UNICODE_FONT: "unicodeFont",
     UPDATE_CONTEXT_MENU: "updateContextMenu",
-    NOTIFICATIONS: "notifications"
+    NOTIFICATIONS: "notifications",
+    INSERT: "insert"
 });

--- a/src/content_scripts/chrome.js
+++ b/src/content_scripts/chrome.js
@@ -5,6 +5,6 @@ document.addEventListener("selectionchange", () => {
     const selection = document.getSelection().toString();
     browser.runtime.sendMessage({
         type: UPDATE_CONTEXT_MENU,
-        selection: selection
+        selection
     });
 });

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -9,12 +9,12 @@
   "homepage_url": "https://github.com/rugk/unicodify",
 
   "options_ui": {
-    "page": "options/options.html",
-    "browser_style": true
+    "page": "options/options.html"
   },
 
   "background": {
-    "page": "background/background.html"
+    "scripts": ["background/modules/InstallUpgrade.js", "background/background.js"],
+    "type": "module"
   },
   "content_scripts": [
     {
@@ -45,7 +45,7 @@
   "browser_specific_settings": {
     "gecko": {
       "id": "unicodify@rugk.github.io",
-      "strict_min_version": "87.0"
+      "strict_min_version": "112.0"
     }
   }
 }

--- a/src/options/modules/CustomOptionTriggers.js
+++ b/src/options/modules/CustomOptionTriggers.js
@@ -30,7 +30,7 @@ function applyAutocorrectPermissions(optionValue, option, event) {
     // trigger update for current session
     browser.runtime.sendMessage({
         type: COMMUNICATION_MESSAGE_TYPE.AUTOCORRECT_BACKGROUND,
-        optionValue: optionValue
+        optionValue
     });
 }
 
@@ -47,7 +47,7 @@ function applyUnicodeFontSettings(optionValue) {
     // trigger update for current session
     browser.runtime.sendMessage({
         type: COMMUNICATION_MESSAGE_TYPE.UNICODE_FONT,
-        optionValue: optionValue
+        optionValue
     });
 }
 
@@ -64,7 +64,7 @@ function applyNotificationSettings(optionValue) {
     // trigger update for current session
     browser.runtime.sendMessage({
         type: COMMUNICATION_MESSAGE_TYPE.NOTIFICATIONS,
-        optionValue: optionValue
+        optionValue
     });
 }
 

--- a/src/options/options.html
+++ b/src/options/options.html
@@ -6,7 +6,7 @@
 		<link rel="stylesheet" href="../common/common.css">
 		<link rel="stylesheet" href="options.css">
 
-		<script type="application/javascript" src="../browser-polyfill.js"></script>
+		<script src="../browser-polyfill.js" type="module"></script>
 		<script async src="./fastLoad.js" type="module"></script>
 
 		<script defer src="../common/common.js" type="module"></script>


### PR DESCRIPTION
* Removed use of `tabs.executeScript()` (required for MV3)
* Updated manifest files:
  * Removed use of `browser_style: true` (required for MV3, see: https://github.com/TinyWebEx/CommonCss/issues/4)
  * Use background scripts instead of a background page (requires Firefox/Thunderbird 112 or greater)
* Updated ESLint version:
  * Made minor ESLint fixes enabling additional rules (see: https://github.com/TinyWebEx/AddonTemplate/issues/6).
* Backported changes to content script from https://github.com/rugk/awesome-emoji-picker/pull/93/commits/2cf1237160cc1d8cbaf759f6bc70f53fca84b6cb