### PR TITLE
Added support for Ada case

### DIFF
--- a/.github/workflows/codacy-analysis.yml
+++ b/.github/workflows/codacy-analysis.yml
@@ -21,7 +21,7 @@ jobs:
     steps:
       # Checkout the repository to the GitHub Actions runner
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       # Execute Codacy Analysis CLI and generate a SARIF output with the security issues identified during the analysis
       - name: Run Codacy Analysis CLI

--- a/README.md
+++ b/README.md
@@ -10,10 +10,10 @@
 This is a (Firefox, Chromium/Chrome and Thunderbird) add-on (WebExtension) that allows you to autocorrect common text sequences and convert text characters to a look like a special font.
 For instance, it converts quotes like `"these"` to `“these”`, which are typographically correct.
 
-Additionally, you can convert text into more than 20 different font styles and casing changes.
+Additionally, you can convert text into more than 40 different font styles and casing changes.
 You can enable and disable any features in the options and adjust more settings regarding the behavior of the add-on.
 
-This extension works with modern Firefox v87 or higher, Chromium/Chrome and Thunderbird v87 or higher.
+This extension works with modern Firefox v112 or higher, Chromium/Chrome and Thunderbird v112 or higher.
 
 ## Download
 
@@ -30,7 +30,7 @@ See:
 * [More screenshots](assets/screenshots)
 
 ## Features
-* Unicode autocorrection as you type:
+* \*Unicode autocorrection as you type:
     * Autocorrect [Unicode symbols](https://en.wikipedia.org/wiki/Miscellaneous_Symbols) (i.e. hyphens `--` with –, fractions `1/4` with ¼, etc.). Supports more than 85 symbols.
     * Use Unicode smart quotes ('single quotes' with ‘Unicode single quotes’ and "double quotes" with “Unicode double quotes”)
     * Convert [fractions](https://en.wikipedia.org/wiki/Number_Forms) and [mathematical constants](https://en.wikipedia.org/wiki/Mathematical_constant) to Unicode characters (i.e. `1234.25` with 1234¼, etc.). Supports all Unicode fraction characters, Pi and e constants.
@@ -49,3 +49,5 @@ See:
 * Compatible with Firefox for Android.
 * Translated into several languages. [Contribute your own language!](./CONTRIBUTING.md#Translations)
 * Settings can be managed by your administrator.
+
+\* The Unicode autocorrection feature is experimental and must be first enabled in the settings.

--- a/assets/texts/en/amoDescription.html
+++ b/assets/texts/en/amoDescription.html
@@ -1,6 +1,4 @@
-This is a (Firefox and Thunderbird) add-on (WebExtension) that allows you to autocorrect common text sequences and convert text characters to a look like a special font.
-For instance, it converts quotes like <code>&quot;these&quot;</code> to <code>“these”</code>, which are typographically correct.
-Additionally, you can convert text into more than 20 different font styles and casing changes.
+This is a (Firefox and Thunderbird) add-on (WebExtension) that allows you to convert text into more than 40 different font styles and casing changes.
 You can enable and disable any features in the options and adjust more settings regarding the behavior of the add-on.
 
 
@@ -31,29 +29,10 @@ Just select text, right-click and let Unicodify convert the text into styles lik
 This is useful on websites that do not support changing the font or text formatting.
 
 
-<b>✍️ Improve your typographic style! ✍️</b>
-
-When writing on any website, this add-on optionally corrects your writing by using proper quotation marks or common symbols like arrows, fractions or mathematical signs.
-
-Some examples:
-<ul>
-	<li><code>...</code> is corrected into <code>…</code></li>
-	<li><code>~=</code> is corrected into <code>≅</code></li>
-	<li><code>+-</code> is corrected into <code>±</code></li>
-	<li><code>-+</code> is corrected into <code>∓</code></li>
-	<li><code>&gt;=</code> is corrected into <code>≥</code></li>
-	<li><code>1/4</code> is corrected into <code>¼</code></li>
-	<li><code>--></code> is corrected into <code>⟶</code></li>
-	<li><code>&lt;==&gt;</code> is corrected into <code>⟺</code></li>
-	<li>and much more…</li>
-</ul>
-
-ℹ️ The Unicode autocorrection feature is experimental and must be enabled in the settings.
-
 <b>📢 More Features 📢</b>
 
 <ul>
-	<li>Unicode autocorrection as you type:<ul>
+	<li>*Unicode autocorrection as you type:<ul>
 			<li>Autocorrect <a href="https://en.wikipedia.org/wiki/Miscellaneous_Symbols">Unicode symbols</a> (i.e. hyphens <code>--</code> with –, fractions <code>1/4</code> with ¼, etc.). Supports more
 				than 85 symbols.</li>
 			<li>Use Unicode smart quotes ('single quotes' with ‘Unicode single quotes’ and "double quotes" with “Unicode double quotes”)</li>
@@ -79,13 +58,14 @@ Some examples:
 	<li>Settings can be managed by your administrator.</li>
 </ul>
 
+* ℹ️ The Unicode autocorrection feature is experimental and must be first enabled in the settings.
 
 
 <b>📝 Development 📝</b>
 The add-on is free/libre open-source software and developed on GitHub. <a href="https://github.com/rugk/unicodify">Fork it on GitHub</a> and contribute.
 <a href="https://github.com/rugk/unicodify/contribute">There are some easy issues to start with.</a>
 
-This extension works with modern Firefox and Thunderbird v87 or higher.
+This extension works with modern Firefox and Thunderbird v112 or higher.
 
 
 <b>🙋‍♀️ Contribute 🙋‍♀️</b>

--- a/assets/texts/en/amoSummary.txt
+++ b/assets/texts/en/amoSummary.txt
@@ -1,1 +1,1 @@
-Easily and quickly autocorrect common symbols as ¼ in text fields and transform text to “Unicode fonts” 𝐟𝐨𝐫 𝔢𝔵𝔞𝔪𝔭𝔩𝔢 𝚕𝚒𝚔𝚎 𝘵𝘩𝘪𝘴 as text characters and change the casing of texts.
+Easily and quickly transform text to “Unicode fonts” 𝐟𝐨𝐫 𝔢𝔵𝔞𝔪𝔭𝔩𝔢 𝚕𝚒𝚔𝚎 𝘵𝘩𝘪𝘴 as text characters and change the casing of texts.

--- a/assets/texts/en/atnDescription.html
+++ b/assets/texts/en/atnDescription.html
@@ -1,10 +1,6 @@
-This is a (Firefox and Thunderbird) add-on (MailExtension) that allows you to autocorrect common text sequences and convert text characters to a look like a special font.
-For instance, it converts quotes like <code>&quot;these&quot;</code> to <code>“these”</code>, which are typographically correct.
-Additionally, you can convert text into more than 20 different font styles and casing changes.
+This is a (Firefox and Thunderbird) add-on (MailExtension) that allows you to convert text into more than 40 different font styles and casing changes.
 You can enable and disable any features in the options and adjust more settings regarding the behavior of the add-on.
 
-
-⚠️ This extension requires at least Thunderbird 111 for the context menu to work in the compose body due to <a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1716976">Bug 1716976</a>.
 
 <b>Convert text to any style you want!</b>
 
@@ -31,29 +27,10 @@ Just select text, right-click and let Unicodify convert the text into styles lik
 </ul>
 
 
-<b>✍️ Improve your typographic style! ✍️</b>
-
-When writing on any e-mail, this add-on optionally corrects your writing by using proper quotation marks or common symbols like arrows, fractions or mathematical signs.
-
-Some examples:
-<ul>
-	<li><code>...</code> is corrected into <code>…</code></li>
-	<li><code>~=</code> is corrected into <code>≅</code></li>
-	<li><code>+-</code> is corrected into <code>±</code></li>
-	<li><code>-+</code> is corrected into <code>∓</code></li>
-	<li><code>&gt;=</code> is corrected into <code>≥</code></li>
-	<li><code>1/4</code> is corrected into <code>¼</code></li>
-	<li><code>--></code> is corrected into <code>⟶</code></li>
-	<li><code>&lt;==&gt;</code> is corrected into <code>⟺</code></li>
-	<li>and much more…</li>
-</ul>
-
-ℹ️ The Unicode autocorrection feature is experimental and must be enabled in the settings.
-
 <b>More Features</b>
 
 <ul>
-	<li>Unicode autocorrection as you type:<ul>
+	<li>*Unicode autocorrection as you type:<ul>
 			<li>Autocorrect <a href="https://en.wikipedia.org/wiki/Miscellaneous_Symbols">Unicode symbols</a> (i.e. hyphens <code>--</code> with –, fractions <code>1/4</code> with ¼, etc.). Supports more
 				than 85 symbols.</li>
 			<li>Use Unicode smart quotes ('single quotes' with ‘Unicode single quotes’ and "double quotes" with “Unicode double quotes”)</li>
@@ -76,13 +53,14 @@ Some examples:
 	<li>Settings can be managed by your administrator.</li>
 </ul>
 
+* ℹ️ The Unicode autocorrection feature is experimental and must be first enabled in the settings.
 
 
 <b>Development</b>
 The add-on is free/libre open-source software and developed on GitHub. <a href="https://github.com/rugk/unicodify">Fork it on GitHub</a> and contribute.
 <a href="https://github.com/rugk/unicodify/contribute">There are some easy issues to start with.</a>
 
-This extension works with modern Firefox and Thunderbird v87 or higher.
+This extension works with modern Firefox and Thunderbird v112 or higher.
 
 
 <b>Contribute</b>

--- a/assets/texts/en/atnSummary.txt
+++ b/assets/texts/en/atnSummary.txt
@@ -1,1 +1,1 @@
-Easily and quickly autocorrect common symbols as ¼, transform text to “Unicode fonts” and change the casing.
+Easily and quickly transform text to “Unicode fonts” and change the casing.

--- a/scripts/manifests/chromemanifest.json
+++ b/scripts/manifests/chromemanifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 2,
   "name": "__MSG_extensionName__",
   "short_name": "__MSG_extensionNameShort__",
-  "version": "0.6",
+  "version": "0.7",
   "author": "Teal Dulcet, rugk",
 
   "description": "__MSG_extensionDescription__",

--- a/scripts/manifests/dev.json
+++ b/scripts/manifests/dev.json
@@ -2,7 +2,7 @@
   "manifest_version": 2,
   "name": "Unicodify DEV VERSION",
   "short_name": "__MSG_extensionNameShort__",
-  "version": "0.6",
+  "version": "0.7",
   "author": "Teal Dulcet, rugk",
 
   "description": "__MSG_extensionDescription__",

--- a/scripts/manifests/firefox.json
+++ b/scripts/manifests/firefox.json
@@ -2,7 +2,7 @@
   "manifest_version": 2,
   "name": "__MSG_extensionName__",
   "short_name": "__MSG_extensionNameShort__",
-  "version": "0.6",
+  "version": "0.7",
   "author": "Teal Dulcet, rugk",
 
   "description": "__MSG_extensionDescription__",

--- a/scripts/manifests/thunderbirdmanifest.json
+++ b/scripts/manifests/thunderbirdmanifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 2,
   "name": "__MSG_extensionName__",
   "short_name": "__MSG_extensionNameShort__",
-  "version": "0.6",
+  "version": "0.7",
   "author": "Teal Dulcet, rugk",
 
   "description": "__MSG_extensionDescription__",

--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -159,6 +159,10 @@
     "message": "Constant case",
     "description": "An entry in the context menu. This is an entry for the case."
   },
+  "menuCodeCaseAdaCase": {
+    "message": "Ada case",
+    "description": "An entry in the context menu. This is an entry for the case."
+  },
   "menuCodeCaseKebabCase": {
     "message": "Kebab case",
     "description": "An entry in the context menu. This is an entry for the case."

--- a/src/background/modules/AutocorrectHandler.js
+++ b/src/background/modules/AutocorrectHandler.js
@@ -236,7 +236,7 @@ export async function init() {
 
     // Thunderbird
     // Remove if part 3 of https://bugzilla.mozilla.org/show_bug.cgi?id=1630786#c4 is ever done
-    if (typeof messenger !== "undefined") {
+    if (browser.composeScripts) {
         browser.composeScripts.register({
             js: [
                 { file: "/content_scripts/autocorrect.js" }

--- a/src/common/modules/UnicodeTransformationHandler.js
+++ b/src/common/modules/UnicodeTransformationHandler.js
@@ -46,11 +46,14 @@ export function transformText(text, transformationId) {
 export function getTransformationType(transformationId) {
     if (transformationId.startsWith(CASE_ID_PREFIX)) {
         return TRANSFORMATION_TYPE.CASING;
-    } else if (transformationId.startsWith(CODE_CASE_ID_PREFIX)) {
+    }
+    if (transformationId.startsWith(CODE_CASE_ID_PREFIX)) {
         return TRANSFORMATION_TYPE.CODE_CASING;
-    } else if (transformationId.startsWith(FONT_ID_PREFIX)) {
+    }
+    if (transformationId.startsWith(FONT_ID_PREFIX)) {
         return TRANSFORMATION_TYPE.FONT;
-    } else if (transformationId.startsWith(FORMAT_ID_PREFIX)) {
+    }
+    if (transformationId.startsWith(FORMAT_ID_PREFIX)) {
         return TRANSFORMATION_TYPE.FORMAT;
     }
     throw new Error(`Error while getting transformation type. Transformation with id=${transformationId} is unknown.`);
@@ -185,7 +188,7 @@ function split(str) {
 
     arr = str.split(re).filter(Boolean);
     // \p{Uppercase}
-    return !arr.length || arr.length > 1 ? arr : arr[0].match(/\p{Upper}*\P{Upper}+|\p{Upper}+/gu);
+    return !arr.length || arr.length > 1 ? arr : arr[0].match(/\p{Upper}\P{Upper}*|\P{Upper}+/gu);
 }
 
 /**
@@ -230,6 +233,16 @@ function constantCase(atext) {
 }
 
 /**
+ * Ada case.
+ *
+ * @param {string} atext
+ * @returns {string}
+ */
+function adaCase(atext) {
+    return split(atext).map(([h, ...t]) => h.toUpperCase() + t.join("").toLowerCase()).join("_");
+}
+
+/**
  * Kebab case.
  *
  * @param {string} atext
@@ -260,6 +273,7 @@ const changeCodeCase = Object.freeze({
     UpperCamelCase: upperCamelCase,
     SnakeCase: snakeCase,
     ConstantCase: constantCase,
+    AdaCase: adaCase,
     KebabCase: kebabCase,
     TrainCase: trainCase
 });

--- a/src/common/modules/data/Fonts.js
+++ b/src/common/modules/data/Fonts.js
@@ -144,6 +144,7 @@ export const menuStructure = Object.freeze({
             `${CODE_CASE_ID_PREFIX}UpperCamelCase`,
             `${CODE_CASE_ID_PREFIX}SnakeCase`,
             `${CODE_CASE_ID_PREFIX}ConstantCase`,
+            `${CODE_CASE_ID_PREFIX}AdaCase`,
             `${CODE_CASE_ID_PREFIX}KebabCase`,
             `${CODE_CASE_ID_PREFIX}TrainCase`
         ]

--- a/src/content_scripts/autocorrect.js
+++ b/src/content_scripts/autocorrect.js
@@ -101,7 +101,7 @@ function insertAtCaret(target, atext) {
     }
 
     // Firefox input and textarea fields: https://bugzilla.mozilla.org/show_bug.cgi?id=1220696
-    if (typeof target.setRangeText === "function") {
+    if (target.setRangeText) {
         const start = target.selectionStart;
         const end = target.selectionEnd;
 
@@ -170,7 +170,7 @@ function deleteCaret(target, atext) {
             }
         }
         // Firefox input and textarea fields: https://bugzilla.mozilla.org/show_bug.cgi?id=1220696
-        else if (typeof target.setRangeText === "function") {
+        else if (target.setRangeText) {
             const start = target.selectionStart;
 
             target.selectionStart = start - atext.length;
@@ -283,7 +283,7 @@ function autocorrect(event) {
         return;
     }
     running = true;
-    const target = event.target;
+    const { target } = event;
     const caretposition = getCaretPosition(target);
     if (caretposition) {
         const value = target.value || target.innerText;
@@ -378,7 +378,7 @@ function undoAutocorrect(event) {
         return;
     }
     running = true;
-    const target = event.target;
+    const { target } = event;
     const caretposition = getCaretPosition(target);
     if (caretposition) {
         if (target === lastTarget && caretposition === lastCaretPosition) {
@@ -406,7 +406,7 @@ function undoAutocorrect(event) {
  * @param {Object} sender
  * @returns {void}
  */
-function handleResponse(message, sender) {
+function handleResponse(message, _sender) {
     if (message.type === AUTOCORRECT_CONTENT) {
         ({
             enabled,

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 2,
   "name": "Unicodify DEV VERSION",
   "short_name": "__MSG_extensionNameShort__",
-  "version": "0.6",
+  "version": "0.7",
   "author": "Teal Dulcet, rugk",
 
   "description": "__MSG_extensionDescription__",

--- a/src/options/modules/CustomOptionTriggers.js
+++ b/src/options/modules/CustomOptionTriggers.js
@@ -16,7 +16,7 @@ import { COMMUNICATION_MESSAGE_TYPE } from "/common/modules/data/BrowserCommunic
  * @param  {Object} [event]
  * @returns {Promise<void>|void}
  */
-function applyAutocorrectPermissions(optionValue, option, event) {
+function applyAutocorrectPermissions(optionValue, _option, _event) {
     if (optionValue.enabled) {
         document.getElementById("autocorrectSymbols").disabled = false;
         document.getElementById("autocorrectUnicodeQuotes").disabled = false;


### PR DESCRIPTION
* Added support for Ada case. Fixes #92 
* Added support for acronyms and single letter words when splitting text for the coding cases
* Incremented version to 0.7
* Minor ESLint and Biome fixes
  * Removed use of the `typeof` operator
* Temporally removed most references to the Unicode autocorrect feature from the AMO/ATN descriptions so we can remove the experimental label

CC: @tDeContes