### PR TITLE
Added support for converting arbitrary fractions

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ For instance, it converts quotes like `"these"` to `“these”`, which are typo
 Additionally, you can convert text into more than 40 different font styles and casing changes.
 You can enable and disable any features in the options and adjust more settings regarding the behavior of the add-on.
 
-This extension works with modern Firefox v112 or higher, Chromium/Chrome and Thunderbird v112 or higher.
+This extension works with modern Firefox v125 or higher, Chromium/Chrome and Thunderbird v125 or higher.
 
 ## Download
 

--- a/assets/texts/en/amoDescription.html
+++ b/assets/texts/en/amoDescription.html
@@ -65,7 +65,7 @@ This is useful on websites that do not support changing the font or text formatt
 The add-on is free/libre open-source software and developed on GitHub. <a href="https://github.com/rugk/unicodify">Fork it on GitHub</a> and contribute.
 <a href="https://github.com/rugk/unicodify/contribute">There are some easy issues to start with.</a>
 
-This extension works with modern Firefox and Thunderbird v112 or higher.
+This extension works with modern Firefox and Thunderbird v125 or higher.
 
 
 <b>🙋‍♀️ Contribute 🙋‍♀️</b>

--- a/assets/texts/en/atnDescription.html
+++ b/assets/texts/en/atnDescription.html
@@ -60,7 +60,7 @@ Just select text, right-click and let Unicodify convert the text into styles lik
 The add-on is free/libre open-source software and developed on GitHub. <a href="https://github.com/rugk/unicodify">Fork it on GitHub</a> and contribute.
 <a href="https://github.com/rugk/unicodify/contribute">There are some easy issues to start with.</a>
 
-This extension works with modern Firefox and Thunderbird v112 or higher.
+This extension works with modern Firefox and Thunderbird v125 or higher.
 
 
 <b>Contribute</b>

--- a/scripts/manifests/dev.json
+++ b/scripts/manifests/dev.json
@@ -45,7 +45,7 @@
   "browser_specific_settings": {
     "gecko": {
       "id": "unicodify@rugk.github.io",
-      "strict_min_version": "112.0"
+      "strict_min_version": "125.0"
     }
   }
 }

--- a/scripts/manifests/firefox.json
+++ b/scripts/manifests/firefox.json
@@ -43,7 +43,7 @@
   "browser_specific_settings": {
     "gecko": {
       "id": "unicodify@rugk.github.io",
-      "strict_min_version": "112.0"
+      "strict_min_version": "125.0"
     }
   }
 }

--- a/scripts/manifests/thunderbirdmanifest.json
+++ b/scripts/manifests/thunderbirdmanifest.json
@@ -47,7 +47,7 @@
   "browser_specific_settings": {
     "gecko": {
       "id": "unicodify@rugk.github.io",
-      "strict_min_version": "112.0"
+      "strict_min_version": "125.0"
     }
   }
 }

--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -122,6 +122,10 @@
     "message": "Change casing",
     "description": "An entry in the context menu. This is an entry for the case."
   },
+  "menuCaseSentenceCase": {
+    "message": "Sentence case.",
+    "description": "An entry in the context menu. This is an entry for the case."
+  },
   "menuCaseLowercase": {
     "message": "Lowercase",
     "description": "An entry in the context menu. This is an entry for the case."

--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -430,12 +430,26 @@
     "description": "This is an option shown in the add-on settings. It describes the optionReplaceQuotes setting."
   },
   "optionConvertFractions": {
-    "message": "Convert fractions and mathematical constants to Unicode characters",
+    "message": "Convert fractions to Unicode characters",
     "description": "This is an option shown in the add-on settings."
   },
   "optionConvertFractionsDescr": {
-    "message": "For example, this will replace $CODE_NUMBER$ with 1234¼.",
+    "message": "For example, this will replace $CODE_FRACTION$ with ¼.",
     "description": "This is an option shown in the add-on settings. It describes the optionConvertFractions setting.",
+    "placeholders": {
+      "code_fraction": {
+        "content": "$1",
+        "example": "<code>1/4</code>"
+      }
+    }
+  },
+  "optionConvertNumbers": {
+    "message": "Convert numbers with fractions and mathematical constants to Unicode characters",
+    "description": "This is an option shown in the add-on settings."
+  },
+  "optionConvertNumbersDescr": {
+    "message": "For example, this will replace $CODE_NUMBER$ with 1234¼.",
+    "description": "This is an option shown in the add-on settings. It describes the optionConvertNumbers setting.",
     "placeholders": {
       "code_number": {
         "content": "$1",

--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -264,6 +264,10 @@
     "message": "Monospace",
     "description": "An entry in the context menu. This is an entry for the Unicode font."
   },
+  "menuFontDoubleStruckDoubleStruck": {
+    "message": "Double-struck",
+    "description": "An entry in the context menu. This is an entry for the Unicode font."
+  },
   "menuFontDoubleStruck": {
     "message": "Double-struck",
     "description": "An entry in the context menu. This is an entry for the Unicode font."

--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -268,6 +268,10 @@
     "message": "Double-struck",
     "description": "An entry in the context menu. This is an entry for the Unicode font."
   },
+  "menuFontOutlined": {
+    "message": "Outlined",
+    "description": "An entry in the context menu. This is an entry for the Unicode font."
+  },
   "menuFontOther": {
     "message": "Other/Emojis",
     "description": "An entry in the context menu. This is an entry for the Unicode font."

--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -404,7 +404,7 @@
     "description": "This is an option shown in the add-on settings."
   },
   "optionAutocorrectSymbolsDescr": {
-    "message": "For example, this will replace $CODE_HYPHEN$ with –, $CODE_ARROW$ with ⟶ and $CODE_FRACTION$ with ¼.",
+    "message": "For example, this will replace $CODE_HYPHEN$ with – and $CODE_ARROW$ with ⟶.",
     "description": "This is an option shown in the add-on settings. It describes the optionAutocorrectSymbols setting.",
     "placeholders": {
       "code_hyphen": {
@@ -414,10 +414,6 @@
       "code_arrow": {
         "content": "$2",
         "example": "<code>--></code>"
-      },
-      "code_fraction": {
-        "content": "$3",
-        "example": "<code>1/4</code>"
       }
     }
   },

--- a/src/background/modules/AutocorrectHandler.js
+++ b/src/background/modules/AutocorrectHandler.js
@@ -44,14 +44,14 @@ function createRegEx(tree) {
 
     for (const char in tree) {
         if (char) {
-            const escaptedChar = char.replace(regExSpecialChars, "\\$&");
+            const escaptedChar = RegExp.escape ? RegExp.escape(char) : char.replaceAll(regExSpecialChars, String.raw`\$&`);
 
             const atree = tree[char];
-            if (!(LEAF in atree && Object.keys(atree).length === 0)) {
+            if (LEAF in atree && Object.keys(atree).length === 0) {
+                characterClass.push(escaptedChar);
+            } else {
                 const recurse = createRegEx(atree);
                 alternatives.push(recurse + escaptedChar);
-            } else {
-                characterClass.push(escaptedChar);
             }
         }
     }
@@ -139,7 +139,7 @@ function applySettings() {
                 continue;
             }
             const aindex = x.indexOf(y);
-            if (aindex >= 0) {
+            if (aindex !== -1) {
                 if (aindex < index) {
                     index = aindex;
                     length = y.length;
@@ -235,7 +235,7 @@ export async function init() {
     setSettings(autocorrect);
 
     // Thunderbird
-    // Remove if part 3 of https://bugzilla.mozilla.org/show_bug.cgi?id=1630786#c4 is ever done
+    // Cannot register scripts in manifest.json file: https://bugzilla.mozilla.org/show_bug.cgi?id=1902843
     if (browser.composeScripts) {
         browser.composeScripts.register({
             js: [

--- a/src/background/modules/AutocorrectHandler.js
+++ b/src/background/modules/AutocorrectHandler.js
@@ -8,9 +8,10 @@ import * as symbols from "/common/modules/data/Symbols.js";
 
 const settings = {
     enabled: null,
-    autocorrectEmojis: null,
+    autocorrectSymbols: null,
     quotes: null,
-    fracts: null
+    fracts: null,
+    numbers: null
 };
 
 // Leaf node
@@ -188,6 +189,7 @@ function setSettings(autocorrect) {
     settings.autocorrectSymbols = autocorrect.autocorrectSymbols;
     settings.quotes = autocorrect.autocorrectUnicodeQuotes;
     settings.fracts = autocorrect.autocorrectUnicodeFracts;
+    settings.numbers = autocorrect.autocorrectUnicodeNumbers;
 
     if (settings.enabled) {
         applySettings();
@@ -213,6 +215,7 @@ function sendSettings(autocorrect) {
                     enabled: settings.enabled,
                     quotes: settings.quotes,
                     fracts: settings.fracts,
+                    numbers: settings.numbers,
                     autocorrections,
                     longest,
                     symbolpatterns: IS_CHROME ? symbolpatterns.source : symbolpatterns,
@@ -260,6 +263,7 @@ browser.runtime.onMessage.addListener((message) => {
             enabled: settings.enabled,
             quotes: settings.quotes,
             fracts: settings.fracts,
+            numbers: settings.numbers,
             autocorrections,
             longest,
             symbolpatterns: IS_CHROME ? symbolpatterns.source : symbolpatterns,

--- a/src/background/modules/ContextMenu.js
+++ b/src/background/modules/ContextMenu.js
@@ -186,13 +186,15 @@ async function createMenu(transformationId, menuItems, unicodeFontSettings, exam
         menuText = menuText.replaceAll("&", "&&");
         if (menuIsShown) {
             menus.update(currentTransformationId, {
-                title: menuText
+                title: menuText,
+                enabled: !exampleText || exampleText !== transformedText
             });
         } else {
             await menus.create({
                 id: currentTransformationId,
                 parentId: transformationId,
                 title: menuText,
+                enabled: !exampleText || exampleText !== transformedText,
                 contexts: ["editable"]
             });
         }

--- a/src/common/modules/UnicodeTransformationHandler.js
+++ b/src/common/modules/UnicodeTransformationHandler.js
@@ -73,8 +73,8 @@ export function getTransformationType(transformationId) {
 function capitalizeEachWord(text) {
     return Array.from(segmenterWord.segment(text), ({ segment, isWordLike }) => {
         if (isWordLike) {
-            const [h, ...t] = segment;
-            return h.toLocaleUpperCase() + t.join("");
+            const [head, ...tail] = segment;
+            return head.toLocaleUpperCase() + tail.join("");
         }
         return segment;
     }).join("");
@@ -87,7 +87,7 @@ function capitalizeEachWord(text) {
  * @returns {string}
  */
 function sentenceCase(text) {
-    return Array.from(segmenterSentence.segment(text), ({ segment: [h, ...t] }) => h.toLocaleUpperCase() + t.join("")).join("");
+    return Array.from(segmenterSentence.segment(text), ({ segment: [head, ...tail] }) => head.toLocaleUpperCase() + tail.join("")).join("");
 }
 
 /**
@@ -226,7 +226,7 @@ function camelCase(atext) {
  * @returns {string}
  */
 function upperCamelCase(atext) {
-    return split(atext).map(([h, ...t]) => h.toUpperCase() + t.join("").toLowerCase()).join("");
+    return split(atext).map(([head, ...tail]) => head.toUpperCase() + tail.join("").toLowerCase()).join("");
 }
 
 /**
@@ -256,7 +256,7 @@ function constantCase(atext) {
  * @returns {string}
  */
 function adaCase(atext) {
-    return split(atext).map(([h, ...t]) => h.toUpperCase() + t.join("").toLowerCase()).join("_");
+    return split(atext).map(([head, ...tail]) => head.toUpperCase() + tail.join("").toLowerCase()).join("_");
 }
 
 /**

--- a/src/common/modules/UnicodeTransformationHandler.js
+++ b/src/common/modules/UnicodeTransformationHandler.js
@@ -1,8 +1,8 @@
 import { fontLetters, formats, CASE_ID_PREFIX, CODE_CASE_ID_PREFIX, FONT_ID_PREFIX, FORMAT_ID_PREFIX, TRANSFORMATION_TYPE } from "/common/modules/data/Fonts.js";
 
 const segmenter = new Intl.Segmenter();
-const segmenter1 = new Intl.Segmenter([], { granularity: "word" });
-const segmenter2 = new Intl.Segmenter([], { granularity: "sentence" });
+const segmenterWord = new Intl.Segmenter([], { granularity: "word" });
+const segmenterSentence = new Intl.Segmenter([], { granularity: "sentence" });
 
 /**
  * Transforms the given text according to the given transformation.
@@ -71,7 +71,7 @@ export function getTransformationType(transformationId) {
  * @returns {string}
  */
 function capitalizeEachWord(text) {
-    return Array.from(segmenter1.segment(text), ({ segment, isWordLike }) => {
+    return Array.from(segmenterWord.segment(text), ({ segment, isWordLike }) => {
         if (isWordLike) {
             const [h, ...t] = segment;
             return h.toLocaleUpperCase() + t.join("");
@@ -87,7 +87,7 @@ function capitalizeEachWord(text) {
  * @returns {string}
  */
 function sentenceCase(text) {
-    return Array.from(segmenter2.segment(text), ({ segment: [h, ...t] }) => h.toLocaleUpperCase() + t.join("")).join("");
+    return Array.from(segmenterSentence.segment(text), ({ segment: [h, ...t] }) => h.toLocaleUpperCase() + t.join("")).join("");
 }
 
 /**

--- a/src/common/modules/data/DefaultSettings.js
+++ b/src/common/modules/data/DefaultSettings.js
@@ -19,7 +19,8 @@ const defaultSettings = {
         enabled: false,
         autocorrectSymbols: true,
         autocorrectUnicodeQuotes: true,
-        autocorrectUnicodeFracts: true
+        autocorrectUnicodeFracts: true,
+        autocorrectUnicodeNumbers: true
     },
     unicodeFont: {
         changeFont: true,

--- a/src/common/modules/data/Fonts.js
+++ b/src/common/modules/data/Fonts.js
@@ -107,7 +107,8 @@ export const menuStructure = Object.freeze({
             `${FONT_ID_PREFIX}Monospace`
         ],
         [`${FONT_ID_PREFIX}DoubleStruck`]: [
-            `${FONT_ID_PREFIX}DoubleStruck`
+            `${FONT_ID_PREFIX}DoubleStruck`,
+            `${FONT_ID_PREFIX}Outlined`
         ],
         [`${SEPARATOR_ID_PREFIX}2`]: [],
         [`${FONT_ID_PREFIX}Other`]: [
@@ -177,6 +178,8 @@ const fonts = Object.freeze({
     FrakturBold: "𝕬𝕭𝕮𝕯𝕰𝕱𝕲𝕳𝕴𝕵𝕶𝕷𝕸𝕹𝕺𝕻𝕼𝕽𝕾𝕿𝖀𝖁𝖂𝖃𝖄𝖅𝖆𝖇𝖈𝖉𝖊𝖋𝖌𝖍𝖎𝖏𝖐𝖑𝖒𝖓𝖔𝖕𝖖𝖗𝖘𝖙𝖚𝖛𝖜𝖝𝖞𝖟",
     Monospace: "𝙰𝙱𝙲𝙳𝙴𝙵𝙶𝙷𝙸𝙹𝙺𝙻𝙼𝙽𝙾𝙿𝚀𝚁𝚂𝚃𝚄𝚅𝚆𝚇𝚈𝚉𝚊𝚋𝚌𝚍𝚎𝚏𝚐𝚑𝚒𝚓𝚔𝚕𝚖𝚗𝚘𝚙𝚚𝚛𝚜𝚝𝚞𝚟𝚠𝚡𝚢𝚣𝟶𝟷𝟸𝟹𝟺𝟻𝟼𝟽𝟾𝟿",
     DoubleStruck: "𝔸𝔹ℂ𝔻𝔼𝔽𝔾ℍ𝕀𝕁𝕂𝕃𝕄ℕ𝕆ℙℚℝ𝕊𝕋𝕌𝕍𝕎𝕏𝕐ℤ𝕒𝕓𝕔𝕕𝕖𝕗𝕘𝕙𝕚𝕛𝕜𝕝𝕞𝕟𝕠𝕡𝕢𝕣𝕤𝕥𝕦𝕧𝕨𝕩𝕪𝕫𝟘𝟙𝟚𝟛𝟜𝟝𝟞𝟟𝟠𝟡",
+    // https://en.wikipedia.org/wiki/Symbols_for_Legacy_Computing_Supplement
+    Outlined: "𜳖𜳗𜳘𜳙𜳚𜳛𜳜𜳝𜳞𜳟𜳠𜳡𜳢𜳣𜳤𜳥𜳦𜳧𜳨𜳩𜳪𜳫𜳬𜳭𜳮𜳯𜳰𜳱𜳲𜳳𜳴𜳵𜳶𜳷𜳸𜳹",
     Circled: " !\"#$%&'()⊛⊕,⊖⊙⊘⓪①②③④⑤⑥⑦⑧⑨:;⧀⊜⧁?@ⒶⒷⒸⒹⒺⒻⒼⒽⒾⒿⓀⓁⓂⓃⓄⓅⓆⓇⓈⓉⓊⓋⓌⓍⓎⓏ[⦸]^_`ⓐⓑⓒⓓⓔⓕⓖⓗⓘⓙⓚⓛⓜⓝⓞⓟⓠⓡⓢⓣⓤⓥⓦⓧⓨⓩ{⦶}~",
     CircledBlack: "🅐🅑🅒🅓🅔🅕🅖🅗🅘🅙🅚🅛🅜🅝🅞🅟🅠🅡🅢🅣🅤🅥🅦🅧🅨🅩⓿❶❷❸❹❺❻❼❽❾",
     Squared: " !\"#$%&'()⧆⊞,⊟⊡⧄0123456789:;<=>?@🄰🄱🄲🄳🄴🄵🄶🄷🄸🄹🄺🄻🄼🄽🄾🄿🅀🅁🅂🅃🅄🅅🅆🅇🅈🅉[⧅]^_`🄰🄱🄲🄳🄴🄵🄶🄷🄸🄹🄺🄻🄼🄽🄾🄿🅀🅁🅂🅃🅄🅅🅆🅇🅈🅉{|}~",

--- a/src/common/modules/data/Fonts.js
+++ b/src/common/modules/data/Fonts.js
@@ -132,6 +132,7 @@ export const menuStructure = Object.freeze({
     },
     [TRANSFORMATION_TYPE.CASING]: {
         [`${CASE_ID_PREFIX}Casing`]: [
+            `${CASE_ID_PREFIX}SentenceCase`,
             `${CASE_ID_PREFIX}Lowercase`,
             `${CASE_ID_PREFIX}Uppercase`,
             `${CASE_ID_PREFIX}CapitalizeEachWord`,

--- a/src/common/modules/data/Fonts.js
+++ b/src/common/modules/data/Fonts.js
@@ -106,7 +106,7 @@ export const menuStructure = Object.freeze({
         [`${FONT_ID_PREFIX}Monospace`]: [
             `${FONT_ID_PREFIX}Monospace`
         ],
-        [`${FONT_ID_PREFIX}DoubleStruck`]: [
+        [`${FONT_ID_PREFIX}DoubleStruckDoubleStruck`]: [
             `${FONT_ID_PREFIX}DoubleStruck`,
             `${FONT_ID_PREFIX}Outlined`
         ],

--- a/src/common/modules/data/Symbols.js
+++ b/src/common/modules/data/Symbols.js
@@ -25,7 +25,7 @@ export const symbols = Object.freeze({
     "<=>": "⇔",
 
     // Fractions
-    "1/4": "¼",
+    /* "1/4": "¼",
     "1/2": "½",
     "3/4": "¾",
     "1/7": "⅐",
@@ -42,7 +42,7 @@ export const symbols = Object.freeze({
     "1/8": "⅛",
     "3/8": "⅜",
     "5/8": "⅝",
-    "7/8": "⅞",
+    "7/8": "⅞", */
 
     // Fira Code (https://github.com/tonsky/FiraCode)
     "<--": "⟵",

--- a/src/content_scripts/autocorrect.js
+++ b/src/content_scripts/autocorrect.js
@@ -21,7 +21,7 @@ const afractions = Object.freeze({
     "⅞": [7, 8]
 });
 
-const fractions = Object.freeze(Object.fromEntries(Object.entries(afractions).map(([f, [n, d]]) => [f, n / d])));
+const fractions = Object.freeze(Object.fromEntries(Object.entries(afractions).map(([fraction, [numerator, denominator]]) => [fraction, numerator / denominator])));
 
 const constants = Object.freeze({
     π: Math.PI,
@@ -74,11 +74,11 @@ function getCaretPosition(target) {
         if (selection.rangeCount !== 1) {
             return null;
         }
-        const _range = selection.getRangeAt(0);
-        if (!_range.collapsed) {
+        const arange = selection.getRangeAt(0);
+        if (!arange.collapsed) {
             return null;
         }
-        const range = _range.cloneRange();
+        const range = arange.cloneRange();
         const temp = document.createTextNode("\0");
         range.insertNode(temp);
         const caretposition = target.innerText.indexOf("\0");
@@ -318,6 +318,7 @@ function autocorrect(event) {
         } else {
             // Convert fractions to Unicode characters
             if (!output && fracts) {
+                // Fractions regular expression: https://regex101.com/r/RtUMrA/1
                 const fractionRegex = /(?<!\/\d*)(?<numerator>\d+)\/(?<denominator>\d+)$/u;
                 const previousText = value.slice(0, caretposition);
                 const regexResult = fractionRegex.exec(previousText);
@@ -327,11 +328,12 @@ function autocorrect(event) {
                         const [fraction] = regexResult;
                         const numerator = Number.parseInt(regexResult.groups.numerator, 10);
                         const denominator = Number.parseInt(regexResult.groups.denominator, 10);
-                        const result = Object.entries(afractions).find(([, [anumerator, adenominator]]) => anumerator === numerator && adenominator === denominator);
+                        const result = Object.entries(afractions).find(([, [n, d]]) => n === numerator && d === denominator);
                         let label;
                         if (result) {
                             [label] = result;
                         } else {
+                            // Fraction slash character: https://en.wikipedia.org/wiki/Numerals_in_Unicode#Fractions
                             label = `${numerator}\u2044${denominator}`;
                         }
                         const index = firstDifferenceIndex(label, fraction);
@@ -345,7 +347,7 @@ function autocorrect(event) {
             }
             // Convert numbers with fractions and mathematical constants to Unicode characters
             if (!output && numbers) {
-                // Numbers regular expression: https://regex101.com/r/7jUaSP/10
+                // Numbers regular expression: https://regex101.com/r/7jUaSP/11
                 // Do not match version numbers: https://github.com/rugk/unicodify/issues/40
                 const numberRegex = /(?<!\.\d*)\d+(?<fractionpart>\.\d+)?$/u;
                 const previousText = value.slice(0, caretposition);

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -45,7 +45,7 @@
   "browser_specific_settings": {
     "gecko": {
       "id": "unicodify@rugk.github.io",
-      "strict_min_version": "112.0"
+      "strict_min_version": "125.0"
     }
   }
 }

--- a/src/options/modules/CustomOptionTriggers.js
+++ b/src/options/modules/CustomOptionTriggers.js
@@ -21,10 +21,12 @@ function applyAutocorrectPermissions(optionValue, _option, _event) {
         document.getElementById("autocorrectSymbols").disabled = false;
         document.getElementById("autocorrectUnicodeQuotes").disabled = false;
         document.getElementById("autocorrectUnicodeFracts").disabled = false;
+        document.getElementById("autocorrectUnicodeNumbers").disabled = false;
     } else {
         document.getElementById("autocorrectSymbols").disabled = true;
         document.getElementById("autocorrectUnicodeQuotes").disabled = true;
         document.getElementById("autocorrectUnicodeFracts").disabled = true;
+        document.getElementById("autocorrectUnicodeNumbers").disabled = true;
     }
 
     // trigger update for current session

--- a/src/options/options.html
+++ b/src/options/options.html
@@ -103,17 +103,17 @@
 							<li>
 								<div class="line">
 									<input class="setting save-on-change" type="checkbox" id="autocorrectUnicodeFracts" data-optiongroup="autocorrect" name="autocorrectUnicodeFracts">
-									<label data-i18n="" data-opt-i18n-keep-children for="autocorrectUnicodeFracts">Convert fractions to Unicode characters</label>
+									<label data-i18n="__MSG_optionConvertFractions__" data-opt-i18n-keep-children for="autocorrectUnicodeFracts">Convert fractions to Unicode characters</label>
 								</div>
-								<span data-i18n="" data-opt-i18n-keep-children class="line indent helper-text">For example, this will replace <code>1/4</code> with ¼.</span>
+								<span data-i18n="__MSG_optionConvertFractionsDescr__" data-opt-i18n-keep-children class="line indent helper-text">For example, this will replace <code>1/4</code> with ¼.</span>
 							</li>
 
 							<li>
 								<div class="line">
 									<input class="setting save-on-change" type="checkbox" id="autocorrectUnicodeNumbers" data-optiongroup="autocorrect" name="autocorrectUnicodeNumbers">
-									<label data-i18n="__MSG_optionConvertFractions__" data-opt-i18n-keep-children for="autocorrectUnicodeNumbers">Convert numbers with fractions and mathematical constants to Unicode characters</label>
+									<label data-i18n="__MSG_optionConvertNumbers__" data-opt-i18n-keep-children for="autocorrectUnicodeNumbers">Convert numbers with fractions and mathematical constants to Unicode characters</label>
 								</div>
-								<span data-i18n="__MSG_optionConvertFractionsDescr__" data-opt-i18n-keep-children class="line indent helper-text">For example, this will replace <code>1234.25</code> with 1234¼.</span>
+								<span data-i18n="__MSG_optionConvertNumbersDescr__" data-opt-i18n-keep-children class="line indent helper-text">For example, this will replace <code>1234.25</code> with 1234¼.</span>
 							</li>
 						</ul>
 					</li>

--- a/src/options/options.html
+++ b/src/options/options.html
@@ -89,7 +89,7 @@
 									<label
 									data-i18n="__MSG_optionAutocorrectSymbols__" for="autocorrectSymbols">Autocorrect Unicode symbols</label>
 								</div>
-								<span data-i18n="__MSG_optionAutocorrectSymbolsDescr__" data-opt-i18n-keep-children class="line indent helper-text">For example, this will replace <code>--</code> with –, <code>--></code> with ⟶ and <code>1/4</code> with ¼.</span>
+								<span data-i18n="__MSG_optionAutocorrectSymbolsDescr__" data-opt-i18n-keep-children class="line indent helper-text">For example, this will replace <code>--</code> with – and <code>--></code> with ⟶.</span>
 							</li>
 
 							<li>
@@ -103,7 +103,15 @@
 							<li>
 								<div class="line">
 									<input class="setting save-on-change" type="checkbox" id="autocorrectUnicodeFracts" data-optiongroup="autocorrect" name="autocorrectUnicodeFracts">
-									<label data-i18n="__MSG_optionConvertFractions__" data-opt-i18n-keep-children for="autocorrectUnicodeFracts">Convert fractions and mathematical constants to Unicode characters</label>
+									<label data-i18n="" data-opt-i18n-keep-children for="autocorrectUnicodeFracts">Convert fractions to Unicode characters</label>
+								</div>
+								<span data-i18n="" data-opt-i18n-keep-children class="line indent helper-text">For example, this will replace <code>1/4</code> with ¼.</span>
+							</li>
+
+							<li>
+								<div class="line">
+									<input class="setting save-on-change" type="checkbox" id="autocorrectUnicodeNumbers" data-optiongroup="autocorrect" name="autocorrectUnicodeNumbers">
+									<label data-i18n="__MSG_optionConvertFractions__" data-opt-i18n-keep-children for="autocorrectUnicodeNumbers">Convert numbers with fractions and mathematical constants to Unicode characters</label>
 								</div>
 								<span data-i18n="__MSG_optionConvertFractionsDescr__" data-opt-i18n-keep-children class="line indent helper-text">For example, this will replace <code>1234.25</code> with 1234¼.</span>
 							</li>


### PR DESCRIPTION
* Added support for converting arbitrary fractions.
* Added dedicated option for the fraction autocorrections. Maybe fixes #10
  * Also, changed them to not autocorrect if there is a preceding or succeeding slash character, per a bug report.
* Added new Sentence case option.
* Added new outlined Unicode font.
  * Requires [support for Unicode 16.0](https://en.wikipedia.org/wiki/Symbols_for_Legacy_Computing_Supplement).
* Changed to disable conversions that do not make any changes. Part of #93
* Updated to use [`Intl.Segmenter`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/Segmenter).
  * Requires Firefox/Thunderbird 125 or greater.
* Updated to optionally use [`RegExp.escape`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/escape) if available.
  * Requires Firefox/Thunderbird 134.

- [ ] @rugk - The new menu item and options page changes need to be localized. 