### PR TITLE
Change the place of `Sentence case.` in the menu `Change casing`

### DIFF
--- a/src/common/modules/data/Fonts.js
+++ b/src/common/modules/data/Fonts.js
@@ -133,10 +133,10 @@ export const menuStructure = Object.freeze({
     },
     [TRANSFORMATION_TYPE.CASING]: {
         [`${CASE_ID_PREFIX}Casing`]: [
-            `${CASE_ID_PREFIX}SentenceCase`,
             `${CASE_ID_PREFIX}Lowercase`,
             `${CASE_ID_PREFIX}Uppercase`,
             `${CASE_ID_PREFIX}CapitalizeEachWord`,
+            `${CASE_ID_PREFIX}SentenceCase`,
             `${CASE_ID_PREFIX}ToggleCase`
         ]
     },


### PR DESCRIPTION
Move `Sentence case.` from the top to after `Capitalize Each Word`.
