### PR TITLE
chore: rename all links/references to repo itself after branch rename

### DIFF
--- a/assets/texts/de/privacy.txt
+++ b/assets/texts/de/privacy.txt
@@ -1,6 +1,6 @@
 Dieses Add-on sendet keine Informationen zum Add-on-Autor oder einer Drittpartei.
 
-Eine Erklärung aller Berechtigungen, die dieses Add-on erfragt, kann auf https://github.com/rugk/unicodify/blob/master/assets/texts/de/permissions.md gefunden werden.
+Eine Erklärung aller Berechtigungen, die dieses Add-on erfragt, kann auf https://github.com/rugk/unicodify/blob/main/assets/texts/de/permissions.md gefunden werden.
 
 == DIENSTE VON DRITTEN ==
 

--- a/assets/texts/en/amoDescription.html
+++ b/assets/texts/en/amoDescription.html
@@ -71,14 +71,14 @@ This extension works with modern Firefox and Thunderbird v125 or higher.
 <b>🙋‍♀️ Contribute 🙋‍♀️</b>
 You can easily get involved in this project and help. Here are some ideas:
 <ul>
-<li>📃 <a href="https://github.com/rugk/unicodify/blob/master/CONTRIBUTING.md#translations">Translate this add-on into multiple languages!</a></li>
-<li>🐛 <a href="https://github.com/rugk/unicodify/blob/master/CONTRIBUTING.md#coding">Fix some easy issues and get started in add-on development</a> (or just try out the development version)</li>
-<li>💡 <a href="https://github.com/rugk/unicodify/blob/master/CONTRIBUTING.md#need-ideas">Or check out some other add-on issues</a> (or translate them).</li>
+<li>📃 <a href="https://github.com/rugk/unicodify/blob/main/CONTRIBUTING.md#translations">Translate this add-on into multiple languages!</a></li>
+<li>🐛 <a href="https://github.com/rugk/unicodify/blob/main/CONTRIBUTING.md#coding">Fix some easy issues and get started in add-on development</a> (or just try out the development version)</li>
+<li>💡 <a href="https://github.com/rugk/unicodify/blob/main/CONTRIBUTING.md#need-ideas">Or check out some other add-on issues</a> (or translate them).</li>
 </ul>
-Or, in any case, <a href="https://github.com/rugk/unicodify/blob/master/CONTRIBUTING.md#support-us">support us by spreading the word!</a> ❤️
+Or, in any case, <a href="https://github.com/rugk/unicodify/blob/main/CONTRIBUTING.md#support-us">support us by spreading the word!</a> ❤️
 
 
 
 <b>💬 Permissions 💬</b>
 This add-on requires as few permissions as possible.
-An explanation of all permissions, this add-on requests, can be found <a href="https://github.com/rugk/unicodify/blob/master/assets/texts/en/permissions.md">on this site</a>.
+An explanation of all permissions, this add-on requests, can be found <a href="https://github.com/rugk/unicodify/blob/main/assets/texts/en/permissions.md">on this site</a>.

--- a/assets/texts/en/atnDescription.html
+++ b/assets/texts/en/atnDescription.html
@@ -66,14 +66,14 @@ This extension works with modern Firefox and Thunderbird v125 or higher.
 <b>Contribute</b>
 You can easily get involved in this project and help. Here are some ideas:
 <ul>
-<li><a href="https://github.com/rugk/unicodify/blob/master/CONTRIBUTING.md#translations">Translate this add-on into multiple languages!</a></li>
-<li><a href="https://github.com/rugk/unicodify/blob/master/CONTRIBUTING.md#coding">Fix some easy issues and get started in add-on development</a> (or just try out the development version)</li>
-<li><a href="https://github.com/rugk/unicodify/blob/master/CONTRIBUTING.md#need-ideas">Or check out some other add-on issues</a> (or translate them).</li>
+<li><a href="https://github.com/rugk/unicodify/blob/main/CONTRIBUTING.md#translations">Translate this add-on into multiple languages!</a></li>
+<li><a href="https://github.com/rugk/unicodify/blob/main/CONTRIBUTING.md#coding">Fix some easy issues and get started in add-on development</a> (or just try out the development version)</li>
+<li><a href="https://github.com/rugk/unicodify/blob/main/CONTRIBUTING.md#need-ideas">Or check out some other add-on issues</a> (or translate them).</li>
 </ul>
-Or, in any case, <a href="https://github.com/rugk/unicodify/blob/master/CONTRIBUTING.md#support-us">support us by spreading the word!</a>  ❤️
+Or, in any case, <a href="https://github.com/rugk/unicodify/blob/main/CONTRIBUTING.md#support-us">support us by spreading the word!</a>  ❤️
 
 
 
 <b>Permissions</b>
 This add-on requires as few permissions as possible.
-An explanation of all permissions, this add-on requests, can be found <a href="https://github.com/rugk/unicodify/blob/master/assets/texts/en/permissions.md">on this site</a>.
+An explanation of all permissions, this add-on requests, can be found <a href="https://github.com/rugk/unicodify/blob/main/assets/texts/en/permissions.md">on this site</a>.

--- a/assets/texts/en/privacy.txt
+++ b/assets/texts/en/privacy.txt
@@ -1,6 +1,6 @@
 This add-on does not send any information to the add-on author or any third-party.
 
-An explanation of all permissions, this add-on requests, can be found at https://github.com/rugk/unicodify/blob/master/assets/texts/en/permissions.md.
+An explanation of all permissions, this add-on requests, can be found at https://github.com/rugk/unicodify/blob/main/assets/texts/en/permissions.md.
 
 == THIRD-PARTY SERVICES ==
 

--- a/assets/texts/fr/privacy.txt
+++ b/assets/texts/fr/privacy.txt
@@ -1,6 +1,6 @@
 Cette extension ne transmet aucune donnée à son auteur ou à des tiers.
 
-Une explication de toutes les permissions nécessaires au fonctionnement de l'extension peut être trouvée ici : https://github.com/rugk/unicodify/blob/master/assets/texts/fr/permissions.md.
+Une explication de toutes les permissions nécessaires au fonctionnement de l'extension peut être trouvée ici : https://github.com/rugk/unicodify/blob/main/assets/texts/fr/permissions.md.
 
 == SERVICES TIERS ==
 

--- a/src/_locales/de/messages.json
+++ b/src/_locales/de/messages.json
@@ -80,7 +80,7 @@
     "hash": "f22661cb0e9cdc8144d0c3cf59f854e3"
   },
   "tipTranslateAddonLink": {
-    "message": "https://github.com/rugk/unicodify/blob/master/CONTRIBUTING.md#translations",
+    "message": "https://github.com/rugk/unicodify/blob/main/CONTRIBUTING.md#translations",
     "description": "The link to a description of the translation service/way you can use.",
     "hash": "f470a3a2293959ea331f9bc3d669f9c6"
   },
@@ -482,7 +482,7 @@
     "hash": "b1434b8b42b1707f37d0531a8efdc7f8"
   },
   "contributorsThanksLink": {
-    "message": "https://github.com/rugk/unicodify/blob/master/CONTRIBUTORS.md",
+    "message": "https://github.com/rugk/unicodify/blob/main/CONTRIBUTORS.md",
     "description": "The link to the CONTRIBUTORS file.",
     "hash": "073019ce53aa124007bb99de9eb37e0f"
   },

--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -65,7 +65,7 @@
     "description": "A tip shown to users that potentially speak another language to translate this add-on."
   },
   "tipTranslateAddonLink": {
-    "message": "https://github.com/rugk/unicodify/blob/master/CONTRIBUTING.md#translations",
+    "message": "https://github.com/rugk/unicodify/blob/main/CONTRIBUTING.md#translations",
     "description": "The link to a description of the translation service/way you can use."
   },
   "tipLearnMore": {
@@ -531,7 +531,7 @@
     }
   },
   "contributorsThanksLink": {
-    "message": "https://github.com/rugk/unicodify/blob/master/CONTRIBUTORS.md",
+    "message": "https://github.com/rugk/unicodify/blob/main/CONTRIBUTORS.md",
     "description": "The link to the CONTRIBUTORS file."
   },
   "contributorsThanksLinkText": {


### PR DESCRIPTION
master was renamed to main but these links still needed update

This was a mass ctrl+f change.