### PR TITLE
Fix install/update notifications & translation messages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "unicodify",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}

--- a/src/_locales/de/messages.json
+++ b/src/_locales/de/messages.json
@@ -1,22 +1,35 @@
 {
   "installNotificationTitle": {
-    "message": "🎉 $ADDON_NAME installiert"
-  },
-  "installNotificationMessage": {
-    "message": "Danke, dass Sie die Erweiterung „$ADDON_NAME“ installiert haben!\nVersion: $VERSION\n\nÖffnen Sie die Optionen, um die Erweiterung zu konfigurieren."
-  },
-  "updateNotificationTitle": {
-    "message": "✨ $ADDON_NAME aktualisiert"
-  },
-  "updateNotificationMessage": {
-    "message": "Die Erweiterung „$ADDON_NAME“ wurde auf Version $VERSION aktualisiert.\nKlicken Sie, um die Versionshinweise zu sehen.\n\n$AUTOCORRECTION_MESSAGE"
-  },
-  "autocorrectionDisabledNow": {
-    "message": "Die experimentelle Unicode-Autokorrekturfunktion ist standardmäßig deaktiviert."
-  },
-  "autocorrectionDisabledEarlier": {
-    "message": "Die experimentelle Unicode-Autokorrekturfunktion war standardmäßig in Version 0.5.1 deaktiviert."
-  },
+  "message": "$ADDON_NAME installiert",
+  "placeholders": {
+    "addon_name": { "content": "$1", "example": "Unicodify" }
+  }
+},
+"installNotificationMessage": {
+  "message": "Danke, dass Sie die Erweiterung „$ADDON_NAME“ installiert haben!\nVersion: $VERSION\n\nÖffnen Sie die Optionen, um die Erweiterung zu konfigurieren.",
+  "placeholders": {
+    "addon_name": { "content": "$1", "example": "Unicodify" },
+    "version": { "content": "$2", "example": "1.2.3" }
+  }
+},
+"updateNotificationTitle": {
+  "message": "$ADDON_NAME aktualisiert",
+  "placeholders": {
+    "addon_name": { "content": "$1", "example": "Unicodify" }
+  }
+},
+"updateNotificationMessage": {
+  "message": "Die Erweiterung „$ADDON_NAME“ wurde auf Version $VERSION aktualisiert.\nKlicken Sie, um die Versionshinweise zu sehen.\n\n$AUTOCORRECTION_MESSAGE",
+  "placeholders": {
+    "addon_name": { "content": "$1", "example": "Unicodify" },
+    "version": { "content": "$2", "example": "1.2.3" },
+    "autocorrection_message": {
+      "content": "$3",
+      "example": "Die experimentelle Unicode-Autokorrekturfunktion ist standardmäßig deaktiviert."
+    }
+  }
+},
+
 
   "extensionName": {
     "message": "Unicodify – Text transformer",

--- a/src/_locales/de/messages.json
+++ b/src/_locales/de/messages.json
@@ -29,7 +29,7 @@
     }
   }
 },
-
+// manifest.json
 
   "extensionName": {
     "message": "Unicodify – Text transformer",

--- a/src/_locales/de/messages.json
+++ b/src/_locales/de/messages.json
@@ -1,5 +1,23 @@
 {
-  // manifest.json
+  "installNotificationTitle": {
+    "message": "🎉 $ADDON_NAME installiert"
+  },
+  "installNotificationMessage": {
+    "message": "Danke, dass Sie die Erweiterung „$ADDON_NAME“ installiert haben!\nVersion: $VERSION\n\nÖffnen Sie die Optionen, um die Erweiterung zu konfigurieren."
+  },
+  "updateNotificationTitle": {
+    "message": "✨ $ADDON_NAME aktualisiert"
+  },
+  "updateNotificationMessage": {
+    "message": "Die Erweiterung „$ADDON_NAME“ wurde auf Version $VERSION aktualisiert.\nKlicken Sie, um die Versionshinweise zu sehen.\n\n$AUTOCORRECTION_MESSAGE"
+  },
+  "autocorrectionDisabledNow": {
+    "message": "Die experimentelle Unicode-Autokorrekturfunktion ist standardmäßig deaktiviert."
+  },
+  "autocorrectionDisabledEarlier": {
+    "message": "Die experimentelle Unicode-Autokorrekturfunktion war standardmäßig in Version 0.5.1 deaktiviert."
+  },
+
   "extensionName": {
     "message": "Unicodify – Text transformer",
     "description": "Name of the extension.",

--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -1,12 +1,12 @@
 {
   "installNotificationTitle": {
-    "message": "🎉 $ADDON_NAME installed"
+    "message": " $ADDON_NAME installed"
   },
   "installNotificationMessage": {
     "message": "Thank you for installing the “$ADDON_NAME” add-on!\nVersion: $VERSION\n\nOpen the options/preferences page to configure this extension."
   },
   "updateNotificationTitle": {
-    "message": "✨ $ADDON_NAME updated"
+    "message": " $ADDON_NAME updated"
   },
   "updateNotificationMessage": {
     "message": "The “$ADDON_NAME” add-on has been updated to version $VERSION.\nClick to see the release notes.\n\n$AUTOCORRECTION_MESSAGE"
@@ -17,6 +17,7 @@
   "autocorrectionDisabledEarlier": {
     "message": "The experimental Unicode autocorrection feature was disabled by default in version 0.5.1."
   },
+  // manifest.json
   "extensionName": {
     "message": "Unicodify – Text transformer",
     "description": "Name of the extension."

--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -1,5 +1,22 @@
 {
-  // manifest.json
+  "installNotificationTitle": {
+    "message": "🎉 $ADDON_NAME installed"
+  },
+  "installNotificationMessage": {
+    "message": "Thank you for installing the “$ADDON_NAME” add-on!\nVersion: $VERSION\n\nOpen the options/preferences page to configure this extension."
+  },
+  "updateNotificationTitle": {
+    "message": "✨ $ADDON_NAME updated"
+  },
+  "updateNotificationMessage": {
+    "message": "The “$ADDON_NAME” add-on has been updated to version $VERSION.\nClick to see the release notes.\n\n$AUTOCORRECTION_MESSAGE"
+  },
+  "autocorrectionDisabledNow": {
+    "message": "The experimental Unicode autocorrection feature has been disabled by default."
+  },
+  "autocorrectionDisabledEarlier": {
+    "message": "The experimental Unicode autocorrection feature was disabled by default in version 0.5.1."
+  },
   "extensionName": {
     "message": "Unicodify – Text transformer",
     "description": "Name of the extension."

--- a/src/_locales/fr/messages.json
+++ b/src/_locales/fr/messages.json
@@ -17,6 +17,7 @@
   "autocorrectionDisabledEarlier": {
     "message": "La fonction expérimentale de correction Unicode était désactivée par défaut dans la version 0.5.1."
   },
+  // manifest.json
   "extensionName": {
     "message": "Unicodify – Text transformer",
     "description": "Name of the extension.",

--- a/src/_locales/fr/messages.json
+++ b/src/_locales/fr/messages.json
@@ -1,5 +1,22 @@
 {
-  // manifest.json
+  "installNotificationTitle": {
+    "message": "🎉 $ADDON_NAME installé"
+  },
+  "installNotificationMessage": {
+    "message": "Merci d'avoir installé l'extension “$ADDON_NAME” !\nVersion : $VERSION\n\nOuvrez les options pour configurer cette extension."
+  },
+  "updateNotificationTitle": {
+    "message": "✨ $ADDON_NAME mis à jour"
+  },
+  "updateNotificationMessage": {
+    "message": "L'extension “$ADDON_NAME” a été mise à jour vers la version $VERSION.\nCliquez pour voir les notes de version.\n\n$AUTOCORRECTION_MESSAGE"
+  },
+  "autocorrectionDisabledNow": {
+    "message": "La fonction expérimentale de correction Unicode a été désactivée par défaut."
+  },
+  "autocorrectionDisabledEarlier": {
+    "message": "La fonction expérimentale de correction Unicode était désactivée par défaut dans la version 0.5.1."
+  },
   "extensionName": {
     "message": "Unicodify – Text transformer",
     "description": "Name of the extension.",

--- a/src/_locales/tr/messages.json
+++ b/src/_locales/tr/messages.json
@@ -1,5 +1,22 @@
 {
-  // manifest.json
+   "installNotificationTitle": {
+    "message": "🎉 $ADDON_NAME yüklendi"
+  },
+  "installNotificationMessage": {
+    "message": "“$ADDON_NAME” eklentisini yüklediğiniz için teşekkürler!\nSürüm: $VERSION\n\nEklentiyi yapılandırmak için seçenekler sayfasını açın."
+  },
+  "updateNotificationTitle": {
+    "message": "✨ $ADDON_NAME güncellendi"
+  },
+  "updateNotificationMessage": {
+    "message": "“$ADDON_NAME” eklentisi $VERSION sürümüne güncellendi.\nSürüm notlarını görmek için tıklayın.\n\n$AUTOCORRECTION_MESSAGE"
+  },
+  "autocorrectionDisabledNow": {
+    "message": "Deneysel Unicode otomatik düzeltme özelliği varsayılan olarak devre dışı bırakıldı."
+  },
+  "autocorrectionDisabledEarlier": {
+    "message": "Deneysel Unicode otomatik düzeltme özelliği 0.5.1 sürümünde varsayılan olarak devre dışı bırakılmıştı."
+  },
   "extensionName": {
     "message": "Unicodify – Text transformer",
     "description": "Name of the extension."

--- a/src/_locales/tr/messages.json
+++ b/src/_locales/tr/messages.json
@@ -17,6 +17,7 @@
   "autocorrectionDisabledEarlier": {
     "message": "Deneysel Unicode otomatik düzeltme özelliği 0.5.1 sürümünde varsayılan olarak devre dışı bırakılmıştı."
   },
+  // manifest.json
   "extensionName": {
     "message": "Unicodify – Text transformer",
     "description": "Name of the extension."

--- a/src/background/modules/InstallUpgrade.js
+++ b/src/background/modules/InstallUpgrade.js
@@ -7,13 +7,10 @@
 import * as Notifications from "/common/modules/Notifications.js";
 import { getBrowserValue } from "/common/modules/BrowserCompat.js";
 
-
 const notifications = new Map();
-
 
 browser.notifications.onClicked.addListener((notificationId) => {
     const url = notifications.get(notificationId);
-
     if (url) {
         browser.tabs.create({ url });
     }
@@ -35,36 +32,52 @@ function handleInstalled(details) {
     console.log(details);
 
     const manifest = browser.runtime.getManifest();
+
     switch (details.reason) {
-    case "install":
-        // TODO(to: 'rugk'): This will need to be localized
-        Notifications.showNotification(`🎉 ${manifest.name} installed`, `Thank you for installing the “${manifest.name}” add-on!\nVersion: ${manifest.version}\n\nOpen the options/preferences page to configure this extension.`);
-        break;
-    case "update":
-        if (Notifications.SEND) {
-            const [major, minor, patch = 0] = details.previousVersion.split(".").map((x) => Number.parseInt(x, 10));
-            // The autocorrection feature was disabled by default in version 0.5.1
-            const disabled = major === 0 && (minor < 5 || minor === 5 && patch === 0);
-            // TODO(to: 'rugk'): This will need to be localized
-            browser.notifications.create({
-                type: "basic",
-                iconUrl: browser.runtime.getURL("icons/icon.svg"),
-                title: `✨ ${manifest.name} updated`,
-                message: `The “${manifest.name}” add-on has been updated to version ${manifest.version}. Click to see the release notes.\n\nThe experimental Unicode autocorrection feature ${disabled ? "has been disabled by default" : "was disabled by default in version 0.5.1"}. Open the options/preferences page to reenable.`
-            }).then(async (notificationId) => {
-                const url = await getBrowserValue({
-                    firefox: `https://addons.mozilla.org/firefox/addon/unicodify-text-transformer/versions/${manifest.version}`,
-                    thunderbird: `https://addons.thunderbird.net/thunderbird/addon/unicodify-text-transformer/versions/${manifest.version}`,
-                    chrome: "" // The Chrome Web Store does not show release notes
-                }) || `https://github.com/rugk/unicodify/releases/v${manifest.version}`;
-                notifications.set(notificationId, url);
-            });
-        }
-        break;
+        case "install":
+            Notifications.showNotification(
+                browser.i18n.getMessage("installNotificationTitle", manifest.name),
+                browser.i18n.getMessage("installNotificationMessage", [manifest.name, manifest.version])
+            );
+            break;
+
+        case "update":
+            if (Notifications.SEND) {
+                const [major, minor, patch = 0] = details.previousVersion
+                    .split(".")
+                    .map((x) => Number.parseInt(x, 10));
+
+                // The autocorrection feature was disabled by default in version 0.5.1
+                const disabled = major === 0 && (minor < 5 || (minor === 5 && patch === 0));
+
+                const autocorrectionMessage = browser.i18n.getMessage(
+                    disabled ? "autocorrectionDisabledNow" : "autocorrectionDisabledEarlier"
+                );
+
+                browser.notifications.create({
+                    type: "basic",
+                    iconUrl: browser.runtime.getURL("icons/icon.svg"),
+                    title: browser.i18n.getMessage("updateNotificationTitle", manifest.name),
+                    message: browser.i18n.getMessage("updateNotificationMessage", [
+                        manifest.name,
+                        manifest.version,
+                        autocorrectionMessage
+                    ])
+                }).then(async (notificationId) => {
+                    const url = await getBrowserValue({
+                        firefox: `https://addons.mozilla.org/firefox/addon/unicodify-text-transformer/versions/${manifest.version}`,
+                        thunderbird: `https://addons.thunderbird.net/thunderbird/addon/unicodify-text-transformer/versions/${manifest.version}`,
+                        chrome: "" // The Chrome Web Store does not show release notes
+                    }) || `https://github.com/rugk/unicodify/releases/v${manifest.version}`;
+
+                    notifications.set(notificationId, url);
+                });
+            }
+            break;
     }
 }
 
 browser.runtime.onInstalled.addListener(handleInstalled);
 
-// Previous exit survey: https://forms.gle/P8ThPXAvbGEkshYDA
+// Previous exit survey
 browser.runtime.setUninstallURL("https://cryptpad.fr/form/#/2/form/view/TyXGnnNjCOo+iC2qrvPzfO8NMK4jMg3pRKxL0mrYNs8/");


### PR DESCRIPTION
This PR fixes the issue where install and update notifications were always shown in English (#105).

Changes made:
- Moved hardcoded notification strings into _locales/*/messages.json
- Replaced direct strings in InstallUpgrade.js with browser.i18n.getMessage
- Added translations for en, fr, de, and tr

Now the notifications will appear in the user's local language.

Closes #105
